### PR TITLE
Add `elbv2` and `ec2` resource references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-03-06T21:37:54Z"
-  build_hash: a5ba3c851434263128a1464a2c41e528779eeefa
-  go_version: go1.22.0
-  version: v0.32.1
-api_directory_checksum: 2743326128daa01af53d7d6559c5bafe0e811f77
+  build_date: "2024-03-24T19:46:46Z"
+  build_hash: ca5ff205b7be9c7fac8f35f8e7a3f6eae22af3ed
+  go_version: go1.22.1
+  version: v0.32.1-2-gca5ff20-dirty
+api_directory_checksum: c4a1c1782ec7095448051eb8b7b87045fd6e1efb
 api_version: v1alpha1
 aws_sdk_go_version: v1.50.20
 generator_config_info:
-  file_checksum: e9f0563f28c1411ec71d21908865a08a3d345a50
+  file_checksum: 877a7022e9b7c4aa55ae3da58b3ea91a6c6e4986
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -187,6 +187,26 @@ resources:
           path: Status.ACKResourceMetadata.ARN
           resource: Role
           service_name: iam
+      LoadBalancers.LoadBalancerName:
+        references:
+          path: Spec.Name
+          resource: LoadBalancer
+          service_name: elbv2
+      LoadBalancers.TargetGroupArn:
+        references:
+          path: Status.ACKResourceMetadata.ARN
+          resource: TargetGroup
+          service_name: elbv2
+      NetworkConfiguration.AwsvpcConfiguration.Subnets:
+        references:
+          path: Status.SubnetID
+          resource: Subnet
+          service_name: ec2
+      NetworkConfiguration.AwsvpcConfiguration.SecurityGroups:
+        references:
+          path: Status.ID
+          resource: SecurityGroup
+          service_name: ec2
     list_operation:
       match_fields:
       - Name

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -31,9 +31,13 @@ var (
 // An object representing the networking details for a task or service. For
 // example awsvpcConfiguration={subnets=["subnet-12344321"],securityGroups=["sg-12344321"]}
 type AWSVPCConfiguration struct {
-	AssignPublicIP *string   `json:"assignPublicIP,omitempty"`
-	SecurityGroups []*string `json:"securityGroups,omitempty"`
-	Subnets        []*string `json:"subnets,omitempty"`
+	AssignPublicIP *string `json:"assignPublicIP,omitempty"`
+	// Reference field for SecurityGroups
+	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
+	SecurityGroups    []*string                                  `json:"securityGroups,omitempty"`
+	// Reference field for Subnets
+	SubnetRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"subnetRefs,omitempty"`
+	Subnets    []*string                                  `json:"subnets,omitempty"`
 }
 
 // An object representing a container instance or task attachment.
@@ -941,7 +945,11 @@ type LoadBalancer struct {
 	ContainerName    *string `json:"containerName,omitempty"`
 	ContainerPort    *int64  `json:"containerPort,omitempty"`
 	LoadBalancerName *string `json:"loadBalancerName,omitempty"`
-	TargetGroupARN   *string `json:"targetGroupARN,omitempty"`
+	// Reference field for LoadBalancerName
+	LoadBalancerRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"loadBalancerRef,omitempty"`
+	TargetGroupARN  *string                                  `json:"targetGroupARN,omitempty"`
+	// Reference field for TargetGroupARN
+	TargetGroupRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetGroupRef,omitempty"`
 }
 
 // The log configuration for the container. This parameter maps to LogConfig

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,17 @@ func (in *AWSVPCConfiguration) DeepCopyInto(out *AWSVPCConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))
@@ -40,6 +51,17 @@ func (in *AWSVPCConfiguration) DeepCopyInto(out *AWSVPCConfiguration) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.SubnetRefs != nil {
+		in, out := &in.SubnetRefs, &out.SubnetRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -2312,10 +2334,20 @@ func (in *LoadBalancer) DeepCopyInto(out *LoadBalancer) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerRef != nil {
+		in, out := &in.LoadBalancerRef, &out.LoadBalancerRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.TargetGroupARN != nil {
 		in, out := &in.TargetGroupARN, &out.TargetGroupARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.TargetGroupRef != nil {
+		in, out := &in.TargetGroupRef, &out.TargetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"os"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	elbv2apitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -60,6 +62,8 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = ec2apitypes.AddToScheme(scheme)
+	_ = elbv2apitypes.AddToScheme(scheme)
 	_ = iamapitypes.AddToScheme(scheme)
 }
 

--- a/config/crd/bases/ecs.services.k8s.aws_services.yaml
+++ b/config/crd/bases/ecs.services.k8s.aws_services.yaml
@@ -360,8 +360,32 @@ spec:
                       type: integer
                     loadBalancerName:
                       type: string
+                    loadBalancerRef:
+                      description: Reference field for LoadBalancerName
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 type: array
               name:
@@ -386,9 +410,45 @@ spec:
                     properties:
                       assignPublicIP:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string
+                        type: array
+                      subnetRefs:
+                        description: Reference field for Subnets
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
                         type: array
                       subnets:
                         items:
@@ -1079,9 +1139,47 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1533,8 +1631,32 @@ spec:
                             type: integer
                           loadBalancerName:
                             type: string
+                          loadBalancerRef:
+                            description: Reference field for LoadBalancerName
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
                           targetGroupARN:
                             type: string
+                          targetGroupRef:
+                            description: Reference field for TargetGroupARN
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
                         type: object
                       type: array
                     networkConfiguration:
@@ -1547,9 +1669,47 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -31,6 +31,34 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ecs.services.k8s.aws
   resources:
   - clusters
@@ -90,6 +118,34 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - loadbalancers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - loadbalancers/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - targetgroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - targetgroups/status
+  verbs:
+  - get
+  - list
 - apiGroups:
   - iam.services.k8s.aws
   resources:

--- a/generator.yaml
+++ b/generator.yaml
@@ -187,6 +187,26 @@ resources:
           path: Status.ACKResourceMetadata.ARN
           resource: Role
           service_name: iam
+      LoadBalancers.LoadBalancerName:
+        references:
+          path: Spec.Name
+          resource: LoadBalancer
+          service_name: elbv2
+      LoadBalancers.TargetGroupArn:
+        references:
+          path: Status.ACKResourceMetadata.ARN
+          resource: TargetGroup
+          service_name: elbv2
+      NetworkConfiguration.AwsvpcConfiguration.Subnets:
+        references:
+          path: Status.SubnetID
+          resource: Subnet
+          service_name: ec2
+      NetworkConfiguration.AwsvpcConfiguration.SecurityGroups:
+        references:
+          path: Status.ID
+          resource: SecurityGroup
+          service_name: ec2
     list_operation:
       match_fields:
       - Name

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/aws-controllers-k8s/ecs-controller
 go 1.21
 
 require (
+	github.com/aws-controllers-k8s/ec2-controller v1.2.4
+	github.com/aws-controllers-k8s/elbv2-controller v0.0.6
 	github.com/aws-controllers-k8s/iam-controller v1.3.4
 	github.com/aws-controllers-k8s/runtime v0.32.0
 	github.com/aws/aws-sdk-go v1.50.20

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/aws-controllers-k8s/ec2-controller v1.2.4 h1:lLm/jH4Zmylykuyjo/P8lgHYCdu4do+apX8A34cA0Rk=
+github.com/aws-controllers-k8s/ec2-controller v1.2.4/go.mod h1:d1pRZ8OyXqokbMNmsVcr/gD6ZZ8EJurOK/6jbiV4y14=
+github.com/aws-controllers-k8s/elbv2-controller v0.0.6 h1:1xbgEs27K5jN10mcbTAZxzuaTCH+0E7DFP7oO6I16u8=
+github.com/aws-controllers-k8s/elbv2-controller v0.0.6/go.mod h1:aPjjoI7kOjAJ03I6sJzv3fICx/tLTG/7TeEcaePhAXo=
 github.com/aws-controllers-k8s/iam-controller v1.3.4 h1:C/CgvJQb6I6mtjgV10FtyWq81S6IhNG+dF4+mjxANEY=
 github.com/aws-controllers-k8s/iam-controller v1.3.4/go.mod h1:8S4IXeK3Y9HABtSwy0Y8X/iBmBH1L/ab1D1cZ0YVlg0=
 github.com/aws-controllers-k8s/runtime v0.32.0 h1:R0dQs8vRlK50KZ7rgdExqExdlUgFSAzDT8q1HCxc1uc=

--- a/helm/crds/ecs.services.k8s.aws_services.yaml
+++ b/helm/crds/ecs.services.k8s.aws_services.yaml
@@ -360,8 +360,32 @@ spec:
                       type: integer
                     loadBalancerName:
                       type: string
+                    loadBalancerRef:
+                      description: Reference field for LoadBalancerName
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 type: array
               name:
@@ -386,9 +410,45 @@ spec:
                     properties:
                       assignPublicIP:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string
+                        type: array
+                      subnetRefs:
+                        description: Reference field for Subnets
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          type: object
                         type: array
                       subnets:
                         items:
@@ -1079,9 +1139,47 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1533,8 +1631,32 @@ spec:
                             type: integer
                           loadBalancerName:
                             type: string
+                          loadBalancerRef:
+                            description: Reference field for LoadBalancerName
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
                           targetGroupARN:
                             type: string
+                          targetGroupRef:
+                            description: Reference field for TargetGroupARN
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            type: object
                         type: object
                       type: array
                     networkConfiguration:
@@ -1547,9 +1669,47 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -78,6 +78,34 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - subnets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - ecs.services.k8s.aws
   resources:
   - clusters
@@ -137,6 +165,34 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - loadbalancers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - loadbalancers/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - targetgroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - elbv2.services.k8s.aws
+  resources:
+  - targetgroups/status
+  verbs:
+  - get
+  - list
 - apiGroups:
   - iam.services.k8s.aws
   resources:

--- a/pkg/resource/service/references.go
+++ b/pkg/resource/service/references.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	elbv2apitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
@@ -30,6 +32,18 @@ import (
 
 	svcapitypes "github.com/aws-controllers-k8s/ecs-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=loadbalancers,verbs=get;list
+// +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=loadbalancers/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=targetgroups,verbs=get;list
+// +kubebuilder:rbac:groups=elbv2.services.k8s.aws,resources=targetgroups/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
@@ -43,6 +57,34 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.ClusterRef != nil {
 		ko.Spec.Cluster = nil
+	}
+
+	for f0idx, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.LoadBalancerRef != nil {
+			ko.Spec.LoadBalancers[f0idx].LoadBalancerName = nil
+		}
+	}
+
+	for f0idx, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.TargetGroupRef != nil {
+			ko.Spec.LoadBalancers[f0idx].TargetGroupARN = nil
+		}
+	}
+
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			if len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs) > 0 {
+				ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups = nil
+			}
+		}
+	}
+
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			if len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SubnetRefs) > 0 {
+				ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets = nil
+			}
+		}
 	}
 
 	if ko.Spec.RoleRef != nil {
@@ -79,6 +121,30 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForLoadBalancers_LoadBalancerName(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForLoadBalancers_TargetGroupARN(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_SecurityGroups(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_Subnets(ctx, apiReader, namespace, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForRole(ctx, apiReader, namespace, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -100,6 +166,34 @@ func validateReferenceFields(ko *svcapitypes.Service) error {
 
 	if ko.Spec.ClusterRef != nil && ko.Spec.Cluster != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Cluster", "ClusterRef")
+	}
+
+	for _, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.LoadBalancerRef != nil && f0iter.LoadBalancerName != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("LoadBalancers.LoadBalancerName", "LoadBalancers.LoadBalancerRef")
+		}
+	}
+
+	for _, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupARN != nil {
+			return ackerr.ResourceReferenceAndIDNotSupportedFor("LoadBalancers.TargetGroupARN", "LoadBalancers.TargetGroupRef")
+		}
+	}
+
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			if len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs) > 0 && len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups) > 0 {
+				return ackerr.ResourceReferenceAndIDNotSupportedFor("NetworkConfiguration.AWSVPCConfiguration.SecurityGroups", "NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs")
+			}
+		}
+	}
+
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			if len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SubnetRefs) > 0 && len(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets) > 0 {
+				return ackerr.ResourceReferenceAndIDNotSupportedFor("NetworkConfiguration.AWSVPCConfiguration.Subnets", "NetworkConfiguration.AWSVPCConfiguration.SubnetRefs")
+			}
+		}
 	}
 
 	if ko.Spec.RoleRef != nil && ko.Spec.Role != nil {
@@ -185,6 +279,336 @@ func getReferencedResourceState_Cluster(
 			"Cluster",
 			namespace, name,
 			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForLoadBalancers_LoadBalancerName reads the resource referenced
+// from LoadBalancers.LoadBalancerRef field and sets the LoadBalancers.LoadBalancerName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForLoadBalancers_LoadBalancerName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Service,
+) (hasReferences bool, err error) {
+	for f0idx, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.LoadBalancerRef != nil && f0iter.LoadBalancerRef.From != nil {
+			hasReferences = true
+			arr := f0iter.LoadBalancerRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: LoadBalancers.LoadBalancerRef")
+			}
+			obj := &elbv2apitypes.LoadBalancer{}
+			if err := getReferencedResourceState_LoadBalancer(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.LoadBalancers[f0idx].LoadBalancerName = (*string)(obj.Spec.Name)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_LoadBalancer looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_LoadBalancer(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *elbv2apitypes.LoadBalancer,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"LoadBalancer",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"LoadBalancer",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"LoadBalancer",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"LoadBalancer",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForLoadBalancers_TargetGroupARN reads the resource referenced
+// from LoadBalancers.TargetGroupRef field and sets the LoadBalancers.TargetGroupARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForLoadBalancers_TargetGroupARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Service,
+) (hasReferences bool, err error) {
+	for f0idx, f0iter := range ko.Spec.LoadBalancers {
+		if f0iter.TargetGroupRef != nil && f0iter.TargetGroupRef.From != nil {
+			hasReferences = true
+			arr := f0iter.TargetGroupRef.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: LoadBalancers.TargetGroupRef")
+			}
+			obj := &elbv2apitypes.TargetGroup{}
+			if err := getReferencedResourceState_TargetGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			ko.Spec.LoadBalancers[f0idx].TargetGroupARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_TargetGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_TargetGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *elbv2apitypes.TargetGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"TargetGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"TargetGroup",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"TargetGroup",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"TargetGroup",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_SecurityGroups reads the resource referenced
+// from NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs field and sets the NetworkConfiguration.AWSVPCConfiguration.SecurityGroups
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_SecurityGroups(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Service,
+) (hasReferences bool, err error) {
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			for _, f0iter := range ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs {
+				if f0iter != nil && f0iter.From != nil {
+					hasReferences = true
+					arr := f0iter.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: NetworkConfiguration.AWSVPCConfiguration.SecurityGroupRefs")
+					}
+					obj := &ec2apitypes.SecurityGroup{}
+					if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					if ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups == nil {
+						ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups = make([]*string, 0, 1)
+					}
+					ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups = append(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SecurityGroups, (*string)(obj.Status.ID))
+				}
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
+	}
+	return nil
+}
+
+// resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_Subnets reads the resource referenced
+// from NetworkConfiguration.AWSVPCConfiguration.SubnetRefs field and sets the NetworkConfiguration.AWSVPCConfiguration.Subnets
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForNetworkConfiguration_AWSVPCConfiguration_Subnets(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Service,
+) (hasReferences bool, err error) {
+	if ko.Spec.NetworkConfiguration != nil {
+		if ko.Spec.NetworkConfiguration.AWSVPCConfiguration != nil {
+			for _, f0iter := range ko.Spec.NetworkConfiguration.AWSVPCConfiguration.SubnetRefs {
+				if f0iter != nil && f0iter.From != nil {
+					hasReferences = true
+					arr := f0iter.From
+					if arr.Name == nil || *arr.Name == "" {
+						return hasReferences, fmt.Errorf("provided resource reference is nil or empty: NetworkConfiguration.AWSVPCConfiguration.SubnetRefs")
+					}
+					obj := &ec2apitypes.Subnet{}
+					if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+						return hasReferences, err
+					}
+					if ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets == nil {
+						ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets = make([]*string, 0, 1)
+					}
+					ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets = append(ko.Spec.NetworkConfiguration.AWSVPCConfiguration.Subnets, (*string)(obj.Status.SubnetID))
+				}
+			}
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Subnet looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Subnet(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.Subnet,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Subnet",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Subnet",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Subnet",
+			namespace, name)
+	}
+	if obj.Status.SubnetID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Subnet",
+			namespace, name,
+			"Status.SubnetID")
 	}
 	return nil
 }


### PR DESCRIPTION
This patch regenerates the controller to add a few resource references
for elbv2 LoadBalancer and TargetGroups, and ec2 Subnets and
SecurityGroups.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
