### PR TITLE
Add `elbv2` and `ec2` resource references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-08-29T17:06:30Z"
-  build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
-  go_version: go1.22.5
-  version: v0.38.1
-api_directory_checksum: 2743326128daa01af53d7d6559c5bafe0e811f77
+  build_date: "2024-10-02T00:23:34Z"
+  build_hash: 2a668bbf0f060fbf914fb8d093d15baa0ddb86e3
+  go_version: go1.22.4
+  version: v0.38.1-2-g2a668bb
+api_directory_checksum: c4a1c1782ec7095448051eb8b7b87045fd6e1efb
 api_version: v1alpha1
 aws_sdk_go_version: v1.50.20
 generator_config_info:
-  file_checksum: e9f0563f28c1411ec71d21908865a08a3d345a50
+  file_checksum: 877a7022e9b7c4aa55ae3da58b3ea91a6c6e4986
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -187,6 +187,26 @@ resources:
           path: Status.ACKResourceMetadata.ARN
           resource: Role
           service_name: iam
+      LoadBalancers.LoadBalancerName:
+        references:
+          path: Spec.Name
+          resource: LoadBalancer
+          service_name: elbv2
+      LoadBalancers.TargetGroupArn:
+        references:
+          path: Status.ACKResourceMetadata.ARN
+          resource: TargetGroup
+          service_name: elbv2
+      NetworkConfiguration.AwsvpcConfiguration.Subnets:
+        references:
+          path: Status.SubnetID
+          resource: Subnet
+          service_name: ec2
+      NetworkConfiguration.AwsvpcConfiguration.SecurityGroups:
+        references:
+          path: Status.ID
+          resource: SecurityGroup
+          service_name: ec2
     list_operation:
       match_fields:
       - Name

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -31,9 +31,13 @@ var (
 // An object representing the networking details for a task or service. For
 // example awsvpcConfiguration={subnets=["subnet-12344321"],securityGroups=["sg-12344321"]}
 type AWSVPCConfiguration struct {
-	AssignPublicIP *string   `json:"assignPublicIP,omitempty"`
-	SecurityGroups []*string `json:"securityGroups,omitempty"`
-	Subnets        []*string `json:"subnets,omitempty"`
+	AssignPublicIP *string `json:"assignPublicIP,omitempty"`
+	// Reference field for SecurityGroups
+	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
+	SecurityGroups    []*string                                  `json:"securityGroups,omitempty"`
+	// Reference field for Subnets
+	SubnetRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"subnetRefs,omitempty"`
+	Subnets    []*string                                  `json:"subnets,omitempty"`
 }
 
 // An object representing a container instance or task attachment.
@@ -941,7 +945,11 @@ type LoadBalancer struct {
 	ContainerName    *string `json:"containerName,omitempty"`
 	ContainerPort    *int64  `json:"containerPort,omitempty"`
 	LoadBalancerName *string `json:"loadBalancerName,omitempty"`
-	TargetGroupARN   *string `json:"targetGroupARN,omitempty"`
+	// Reference field for LoadBalancerName
+	LoadBalancerRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"loadBalancerRef,omitempty"`
+	TargetGroupARN  *string                                  `json:"targetGroupARN,omitempty"`
+	// Reference field for TargetGroupARN
+	TargetGroupRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"targetGroupRef,omitempty"`
 }
 
 // The log configuration for the container. This parameter maps to LogConfig

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -32,6 +32,17 @@ func (in *AWSVPCConfiguration) DeepCopyInto(out *AWSVPCConfiguration) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupRefs != nil {
+		in, out := &in.SecurityGroupRefs, &out.SecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]*string, len(*in))
@@ -40,6 +51,17 @@ func (in *AWSVPCConfiguration) DeepCopyInto(out *AWSVPCConfiguration) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.SubnetRefs != nil {
+		in, out := &in.SubnetRefs, &out.SubnetRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -2312,10 +2334,20 @@ func (in *LoadBalancer) DeepCopyInto(out *LoadBalancer) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LoadBalancerRef != nil {
+		in, out := &in.LoadBalancerRef, &out.LoadBalancerRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.TargetGroupARN != nil {
 		in, out := &in.TargetGroupARN, &out.TargetGroupARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.TargetGroupRef != nil {
+		in, out := &in.TargetGroupRef, &out.TargetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"os"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	elbv2apitypes "github.com/aws-controllers-k8s/elbv2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -60,6 +62,8 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = ec2apitypes.AddToScheme(scheme)
+	_ = elbv2apitypes.AddToScheme(scheme)
 	_ = iamapitypes.AddToScheme(scheme)
 }
 

--- a/config/crd/bases/ecs.services.k8s.aws_clusters.yaml
+++ b/config/crd/bases/ecs.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: clusters.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -56,7 +56,6 @@ spec:
             description: |-
               ClusterSpec defines the desired state of Cluster.
 
-
               A regional grouping of one or more container instances where you can run
               task requests. Each account receives a default cluster the first time you
               use the Amazon ECS service, but you may also create other clusters. Clusters
@@ -71,18 +70,15 @@ spec:
                   or RunTask (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html)
                   actions.
 
-
                   If specifying a capacity provider that uses an Auto Scaling group, the capacity
                   provider must be created but not associated with another cluster. New Auto
                   Scaling group capacity providers can be created with the CreateCapacityProvider
                   (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCapacityProvider.html)
                   API operation.
 
-
                   To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                   capacity providers. The Fargate capacity providers are available to all accounts
                   and only need to be associated with a cluster to be used.
-
 
                   The PutCapacityProvider (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutCapacityProvider.html)
                   API operation is used to update the list of available capacity providers
@@ -127,7 +123,6 @@ spec:
                   APIs with no capacity provider strategy or launch type specified, the default
                   capacity provider strategy for the cluster is used.
 
-
                   If a default capacity provider strategy isn't defined for a cluster when
                   it was created, it can be defined later with the PutClusterCapacityProviders
                   API operation.
@@ -137,23 +132,19 @@ spec:
                     can be set when using the RunTask or CreateCluster APIs or as the default
                     capacity provider strategy for a cluster with the CreateCluster API.
 
-
                     Only capacity providers that are already associated with a cluster and have
                     an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                     The PutClusterCapacityProviders API is used to associate a capacity provider
                     with a cluster.
 
-
                     If specifying a capacity provider that uses an Auto Scaling group, the capacity
                     provider must already be created. New Auto Scaling group capacity providers
                     can be created with the CreateCapacityProvider API operation.
-
 
                     To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                     capacity providers. The Fargate capacity providers are available to all accounts
                     and only need to be associated with a cluster to be used in a capacity provider
                     strategy.
-
 
                     A capacity provider strategy may contain a maximum of 6 capacity providers.
                   properties:
@@ -182,7 +173,6 @@ spec:
                   parameter to true in the ServiceConnectConfiguration. You can set the namespace
                   of each service individually in the ServiceConnectConfiguration to override
                   this default parameter.
-
 
                   Tasks that run in a namespace can use short names to connect to services
                   in the namespace. Tasks can connect to services across all of the clusters
@@ -216,31 +206,23 @@ spec:
                   The metadata that you apply to the cluster to help you categorize and organize
                   them. Each tag consists of a key and an optional value. You define both.
 
-
                   The following basic restrictions apply to tags:
 
-
                      * Maximum number of tags per resource - 50
-
 
                      * For each resource, each tag key must be unique, and each tag key can
                      have only one value.
 
-
                      * Maximum key length - 128 Unicode characters in UTF-8
 
-
                      * Maximum value length - 256 Unicode characters in UTF-8
-
 
                      * If your tagging schema is used across multiple services and resources,
                      remember that other services may have restrictions on allowed characters.
                      Generally allowed characters are: letters, numbers, and spaces representable
                      in UTF-8, and the following characters: + - = . _ : / @.
 
-
                      * Tag keys and values are case-sensitive.
-
 
                      * Do not use aws:, AWS:, or any upper or lowercase combination of such
                      as a prefix for either keys or values as it is reserved for Amazon Web
@@ -251,31 +233,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                        * Maximum number of tags per resource - 50
-
 
                        * For each resource, each tag key must be unique, and each tag key can
                        have only one value.
 
-
                        * Maximum key length - 128 Unicode characters in UTF-8
 
-
                        * Maximum value length - 256 Unicode characters in UTF-8
-
 
                        * If your tagging schema is used across multiple services and resources,
                        remember that other services may have restrictions on allowed characters.
                        Generally allowed characters are: letters, numbers, and spaces representable
                        in UTF-8, and the following characters: + - = . _ : / @.
 
-
                        * Tag keys and values are case-sensitive.
-
 
                        * Do not use aws:, AWS:, or any upper or lowercase combination of such
                        as a prefix for either keys or values as it is reserved for Amazon Web
@@ -306,7 +280,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -360,21 +333,15 @@ spec:
                   The status of the capacity providers associated with the cluster. The following
                   are the states that are returned.
 
-
                   UPDATE_IN_PROGRESS
-
 
                   The available capacity providers for the cluster are updating.
 
-
                   UPDATE_COMPLETE
-
 
                   The capacity providers have successfully updated.
 
-
                   UPDATE_FAILED
-
 
                   The capacity provider updates failed.
                 type: string
@@ -434,27 +401,19 @@ spec:
                   Additional information about your clusters that are separated by launch type.
                   They include the following:
 
-
                      * runningEC2TasksCount
-
 
                      * RunningFargateTasksCount
 
-
                      * pendingEC2TasksCount
-
 
                      * pendingFargateTasksCount
 
-
                      * activeEC2ServiceCount
-
 
                      * activeFargateServiceCount
 
-
                      * drainingEC2ServiceCount
-
 
                      * drainingFargateServiceCount
                 items:
@@ -471,37 +430,27 @@ spec:
                   The status of the cluster. The following are the possible states that are
                   returned.
 
-
                   ACTIVE
-
 
                   The cluster is ready to accept tasks and if applicable you can register container
                   instances with the cluster.
 
-
                   PROVISIONING
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider are being created.
 
-
                   DEPROVISIONING
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider are being deleted.
 
-
                   FAILED
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider have failed to create.
 
-
                   INACTIVE
-
 
                   The cluster has been deleted. Clusters with an INACTIVE status may remain
                   discoverable in your account for a period of time. However, this behavior

--- a/config/crd/bases/ecs.services.k8s.aws_services.yaml
+++ b/config/crd/bases/ecs.services.k8s.aws_services.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: services.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -62,18 +62,15 @@ spec:
             description: |-
               ServiceSpec defines the desired state of Service.
 
-
               Details on a service within a cluster.
             properties:
               capacityProviderStrategy:
                 description: |-
                   The capacity provider strategy to use for the service.
 
-
                   If a capacityProviderStrategy is specified, the launchType parameter must
                   be omitted. If no capacityProviderStrategy or launchType is specified, the
                   defaultCapacityProviderStrategy for the cluster is used.
-
 
                   A capacity provider strategy may contain a maximum of 6 capacity providers.
                 items:
@@ -82,23 +79,19 @@ spec:
                     can be set when using the RunTask or CreateCluster APIs or as the default
                     capacity provider strategy for a cluster with the CreateCluster API.
 
-
                     Only capacity providers that are already associated with a cluster and have
                     an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                     The PutClusterCapacityProviders API is used to associate a capacity provider
                     with a cluster.
 
-
                     If specifying a capacity provider that uses an Auto Scaling group, the capacity
                     provider must already be created. New Auto Scaling group capacity providers
                     can be created with the CreateCapacityProvider API operation.
-
 
                     To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                     capacity providers. The Fargate capacity providers are available to all accounts
                     and only need to be associated with a cluster to be used in a capacity provider
                     strategy.
-
 
                     A capacity provider strategy may contain a maximum of 6 capacity providers.
                   properties:
@@ -121,7 +114,7 @@ spec:
               clusterRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -146,15 +139,12 @@ spec:
                       deployment has failed, and then to optionally roll back the failure to the
                       last working deployment.
 
-
                       When the alarms are generated, Amazon ECS sets the service deployment to
                       failed. Set the rollback parameter to have Amazon ECS to roll back your service
                       to the last completed deployment after a failure.
 
-
                       You can only use the DeploymentAlarms method to detect failures when the
                       DeploymentController is set to ECS (rolling update).
-
 
                       For more information, see Rolling update (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html)
                       in the Amazon Elastic Container Service Developer Guide .
@@ -173,14 +163,12 @@ spec:
                       The deployment circuit breaker can only be used for services using the rolling
                       update (ECS) deployment type.
 
-
                       The deployment circuit breaker determines whether a service deployment will
                       fail if the service can't reach a steady state. If it is turned on, a service
                       deployment will transition to a failed state and stop launching new tasks.
                       You can also configure Amazon ECS to roll back your service to the last completed
                       deployment after a failure. For more information, see Rolling update (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html)
                       in the Amazon Elastic Container Service Developer Guide.
-
 
                       For more information about API failure reasons, see API failure reasons (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html)
                       in the Amazon Elastic Container Service Developer Guide.
@@ -210,7 +198,6 @@ spec:
                   The number of instantiations of the specified task definition to place and
                   keep running in your service.
 
-
                   This is required if schedulingStrategy is REPLICA or isn't specified. If
                   schedulingStrategy is DAEMON then this isn't required.
                 format: int64
@@ -221,7 +208,6 @@ spec:
                   the service. For more information, see Tagging your Amazon ECS resources
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   When you use Amazon ECS managed tags, you need to set the propagateTags request
                   parameter.
@@ -240,11 +226,9 @@ spec:
                   balancer. If your service has a load balancer defined and you don't specify
                   a health check grace period value, the default value of 0 is used.
 
-
                   If you do not use an Elastic Load Balancing, we recommend that you use the
                   startPeriod in the task definition health check parameters. For more information,
                   see Health check (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html).
-
 
                   If your service's tasks take a while to start and respond to Elastic Load
                   Balancing health checks, you can specify a health check grace period of up
@@ -260,23 +244,18 @@ spec:
                   Amazon ECS launch types (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   The FARGATE launch type runs your tasks on Fargate On-Demand infrastructure.
-
 
                   Fargate Spot infrastructure is available for use but a capacity provider
                   strategy must be used. For more information, see Fargate capacity providers
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html)
                   in the Amazon ECS User Guide for Fargate.
 
-
                   The EC2 launch type runs your tasks on Amazon EC2 instances registered to
                   your cluster.
 
-
                   The EXTERNAL launch type runs your tasks on your on-premises server or virtual
                   machine (VM) capacity registered to your cluster.
-
 
                   A service can use either a launch type or a capacity provider strategy. If
                   a launchType is specified, the capacityProviderStrategy parameter must be
@@ -288,14 +267,12 @@ spec:
                   For more information, see Service load balancing (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   If the service uses the rolling update (ECS) deployment controller and using
                   either an Application Load Balancer or Network Load Balancer, you must specify
                   one or more target group ARNs to attach to the service. The service-linked
                   role is required for services that use multiple target groups. For more information,
                   see Using service-linked roles for Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   If the service uses the CODE_DEPLOY deployment controller, the service is
                   required to use either an Application Load Balancer or Network Load Balancer.
@@ -308,10 +285,8 @@ spec:
                   that you can use to perform validation tests with Lambda functions before
                   routing production traffic to it.
 
-
                   If you use the CODE_DEPLOY deployment controller, these values can be changed
                   when updating the service.
-
 
                   For Application Load Balancers and Network Load Balancers, this object must
                   contain the load balancer target group ARN, the container name, and the container
@@ -321,14 +296,12 @@ spec:
                   instance and port combination is registered as a target in the target group
                   that's specified here.
 
-
                   For Classic Load Balancers, this object must contain the load balancer name,
                   the container name , and the container port to access from the load balancer.
                   The container name must be as it appears in a container definition. The target
                   group ARN parameter must be omitted. When a task from this service is placed
                   on a container instance, the container instance is registered with the load
                   balancer that's specified here.
-
 
                   Services with tasks that use the awsvpc network mode (for example, those
                   with the Fargate launch type) only support Application Load Balancers and
@@ -341,15 +314,12 @@ spec:
                   description: |-
                     The load balancer configuration to use with a service or task set.
 
-
                     When you add, update, or remove a load balancer configuration, Amazon ECS
                     starts a new deployment with the updated Elastic Load Balancing configuration.
                     This causes tasks to register to and deregister from load balancers.
 
-
                     We recommend that you verify this on a test environment before you update
                     the Elastic Load Balancing configuration.
-
 
                     A service-linked role is required for services that use multiple target groups.
                     For more information, see Using service-linked roles (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
@@ -362,8 +332,36 @@ spec:
                       type: integer
                     loadBalancerName:
                       type: string
+                    loadBalancerRef:
+                      description: Reference field for LoadBalancerName
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 type: array
               name:
@@ -388,9 +386,49 @@ spec:
                     properties:
                       assignPublicIP:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string
+                        type: array
+                      subnetRefs:
+                        description: Reference field for Subnets
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
                         type: array
                       subnets:
                         items:
@@ -408,7 +446,6 @@ spec:
                     An object representing a constraint on task placement. For more information,
                     see Task placement constraints (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
                     in the Amazon Elastic Container Service Developer Guide.
-
 
                     If you're using the Fargate launch type, task placement constraints aren't
                     supported.
@@ -451,7 +488,6 @@ spec:
                   use the TagResource (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TagResource.html)
                   API action.
 
-
                   The default is NONE.
                 type: string
               role:
@@ -463,7 +499,6 @@ spec:
                   parameter, you must also specify a load balancer object with the loadBalancers
                   parameter.
 
-
                   If your account has already created the Amazon ECS service-linked role, that
                   role is used for your service unless you specify a role here. The service-linked
                   role is required if your task definition uses the awsvpc network mode or
@@ -472,7 +507,6 @@ spec:
                   which case you don't specify a role here. For more information, see Using
                   service-linked roles for Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   If your specified role has a path other than /, then you must either specify
                   the full role ARN (this is recommended) or prefix the role name with the
@@ -484,7 +518,7 @@ spec:
               roleRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -503,9 +537,7 @@ spec:
                   The scheduling strategy to use for the service. For more information, see
                   Services (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html).
 
-
                   There are two service scheduler strategies available:
-
 
                      * REPLICA-The replica scheduling strategy places and maintains the desired
                      number of tasks across your cluster. By default, the service scheduler
@@ -513,7 +545,6 @@ spec:
                      and constraints to customize task placement decisions. This scheduler
                      strategy is required if the service uses the CODE_DEPLOY or EXTERNAL deployment
                      controller types.
-
 
                      * DAEMON-The daemon scheduling strategy deploys exactly one task on each
                      active container instance that meets all of the task placement constraints
@@ -529,7 +560,6 @@ spec:
                 description: |-
                   The configuration for this service to discover and connect to services, and
                   be discovered by, and connected from, other services within a namespace.
-
 
                   Tasks that run in a namespace can use short names to connect to services
                   in the namespace. Tasks can connect to services across all of the clusters
@@ -548,7 +578,6 @@ spec:
                       section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                       and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                       By default, containers use the same logging driver that the Docker daemon
                       uses. However, the container might use a different logging driver than the
                       Docker daemon by specifying a log driver configuration in the container definition.
@@ -556,9 +585,7 @@ spec:
                       see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                       in the Docker documentation.
 
-
                       Understand the following when specifying a log configuration for your containers.
-
 
                          * Amazon ECS currently supports a subset of the logging drivers available
                          to the Docker daemon. Additional log drivers may be available in future
@@ -567,10 +594,8 @@ spec:
                          hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                          fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                          * This parameter requires version 1.18 of the Docker Remote API or greater
                          on your container instance.
-
 
                          * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                          agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -578,7 +603,6 @@ spec:
                          these log configuration options. For more information, see Amazon ECS
                          container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                          in the Amazon Elastic Container Service Developer Guide.
-
 
                          * For tasks that are on Fargate, because you don't have access to the
                          underlying infrastructure your tasks are hosted on, any additional software
@@ -598,14 +622,11 @@ spec:
                             An object representing the secret to expose to your container. Secrets can
                             be exposed to a container in the following ways:
 
-
                                * To inject sensitive data into your containers as environment variables,
                                use the secrets container definition parameter.
 
-
                                * To reference sensitive information in the log configuration of a container,
                                use the secretOptions container definition parameter.
-
 
                             For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                             in the Amazon Elastic Container Service Developer Guide.
@@ -632,9 +653,7 @@ spec:
                               Each alias ("endpoint") is a fully-qualified name and port number that other
                               tasks ("clients") can use to connect to this service.
 
-
                               Each name and port mapping must be unique within the namespace.
-
 
                               Tasks that run in a namespace can use short names to connect to services
                               in the namespace. Tasks can connect to services across all of the clusters
@@ -661,7 +680,6 @@ spec:
                         timeout:
                           description: |-
                             An object that represents the timeout configurations for Service Connect.
-
 
                             If idleTimeout is set to a time that is less than perRequestTimeout, the
                             connection will close when the idleTimeout is reached and not the perRequestTimeout.
@@ -698,17 +716,14 @@ spec:
                   The details of the service discovery registry to associate with this service.
                   For more information, see Service discovery (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html).
 
-
                   Each service may be associated with one service registry. Multiple service
                   registries for each service isn't supported.
                 items:
                   description: |-
                     The details for the service registry.
 
-
                     Each service may be associated with one service registry. Multiple service
                     registries for each service are not supported.
-
 
                     When you add, update, or remove the service registries configuration, Amazon
                     ECS starts a new deployment. New tasks are registered and deregistered to
@@ -732,31 +747,23 @@ spec:
                   them. Each tag consists of a key and an optional value, both of which you
                   define. When a service is deleted, the tags are deleted as well.
 
-
                   The following basic restrictions apply to tags:
 
-
                      * Maximum number of tags per resource - 50
-
 
                      * For each resource, each tag key must be unique, and each tag key can
                      have only one value.
 
-
                      * Maximum key length - 128 Unicode characters in UTF-8
 
-
                      * Maximum value length - 256 Unicode characters in UTF-8
-
 
                      * If your tagging schema is used across multiple services and resources,
                      remember that other services may have restrictions on allowed characters.
                      Generally allowed characters are: letters, numbers, and spaces representable
                      in UTF-8, and the following characters: + - = . _ : / @.
 
-
                      * Tag keys and values are case-sensitive.
-
 
                      * Do not use aws:, AWS:, or any upper or lowercase combination of such
                      as a prefix for either keys or values as it is reserved for Amazon Web
@@ -767,31 +774,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                        * Maximum number of tags per resource - 50
-
 
                        * For each resource, each tag key must be unique, and each tag key can
                        have only one value.
 
-
                        * Maximum key length - 128 Unicode characters in UTF-8
 
-
                        * Maximum value length - 256 Unicode characters in UTF-8
-
 
                        * If your tagging schema is used across multiple services and resources,
                        remember that other services may have restrictions on allowed characters.
                        Generally allowed characters are: letters, numbers, and spaces representable
                        in UTF-8, and the following characters: + - = . _ : / @.
 
-
                        * Tag keys and values are case-sensitive.
-
 
                        * Do not use aws:, AWS:, or any upper or lowercase combination of such
                        as a prefix for either keys or values as it is reserved for Amazon Web
@@ -810,10 +809,8 @@ spec:
                   to run in your service. If a revision isn't specified, the latest ACTIVE
                   revision is used.
 
-
                   A task definition must be specified if the service uses either the ECS or
                   CODE_DEPLOY deployment controllers.
-
 
                   For more information about deployment types, see Amazon ECS deployment types
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-types.html).
@@ -821,7 +818,7 @@ spec:
               taskDefinitionRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -851,7 +848,6 @@ spec:
                         The configuration for the Amazon EBS volume that Amazon ECS creates and manages
                         on your behalf. These settings are used to create each Amazon EBS volume,
                         with one volume created for each task in the service.
-
 
                         Many of these parameters map 1:1 with the Amazon EBS CreateVolume API request
                         parameters.
@@ -886,31 +882,23 @@ spec:
                                     The metadata that you apply to a resource to help you categorize and organize
                                     them. Each tag consists of a key and an optional value. You define them.
 
-
                                     The following basic restrictions apply to tags:
 
-
                                        * Maximum number of tags per resource - 50
-
 
                                        * For each resource, each tag key must be unique, and each tag key can
                                        have only one value.
 
-
                                        * Maximum key length - 128 Unicode characters in UTF-8
 
-
                                        * Maximum value length - 256 Unicode characters in UTF-8
-
 
                                        * If your tagging schema is used across multiple services and resources,
                                        remember that other services may have restrictions on allowed characters.
                                        Generally allowed characters are: letters, numbers, and spaces representable
                                        in UTF-8, and the following characters: + - = . _ : / @.
 
-
                                        * Tag keys and values are case-sensitive.
-
 
                                        * Do not use aws:, AWS:, or any upper or lowercase combination of such
                                        as a prefix for either keys or values as it is reserved for Amazon Web
@@ -955,7 +943,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -1032,23 +1019,19 @@ spec:
                           can be set when using the RunTask or CreateCluster APIs or as the default
                           capacity provider strategy for a cluster with the CreateCluster API.
 
-
                           Only capacity providers that are already associated with a cluster and have
                           an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                           The PutClusterCapacityProviders API is used to associate a capacity provider
                           with a cluster.
 
-
                           If specifying a capacity provider that uses an Auto Scaling group, the capacity
                           provider must already be created. New Auto Scaling group capacity providers
                           can be created with the CreateCapacityProvider API operation.
-
 
                           To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                           capacity providers. The Fargate capacity providers are available to all accounts
                           and only need to be associated with a cluster to be used in a capacity provider
                           strategy.
-
 
                           A capacity provider strategy may contain a maximum of 6 capacity providers.
                         properties:
@@ -1085,9 +1068,51 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1115,7 +1140,6 @@ spec:
                         for this service to discover and connect to services, and be discovered by,
                         and connected from, other services within a namespace.
 
-
                         Tasks that run in a namespace can use short names to connect to services
                         in the namespace. Tasks can connect to services across all of the clusters
                         in the namespace. Tasks connect through a managed proxy container that collects
@@ -1133,7 +1157,6 @@ spec:
                             section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                             and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                             By default, containers use the same logging driver that the Docker daemon
                             uses. However, the container might use a different logging driver than the
                             Docker daemon by specifying a log driver configuration in the container definition.
@@ -1141,9 +1164,7 @@ spec:
                             see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                             in the Docker documentation.
 
-
                             Understand the following when specifying a log configuration for your containers.
-
 
                                * Amazon ECS currently supports a subset of the logging drivers available
                                to the Docker daemon. Additional log drivers may be available in future
@@ -1152,10 +1173,8 @@ spec:
                                hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                                fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                                * This parameter requires version 1.18 of the Docker Remote API or greater
                                on your container instance.
-
 
                                * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                                agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -1163,7 +1182,6 @@ spec:
                                these log configuration options. For more information, see Amazon ECS
                                container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                                in the Amazon Elastic Container Service Developer Guide.
-
 
                                * For tasks that are on Fargate, because you don't have access to the
                                underlying infrastructure your tasks are hosted on, any additional software
@@ -1183,14 +1201,11 @@ spec:
                                   An object representing the secret to expose to your container. Secrets can
                                   be exposed to a container in the following ways:
 
-
                                      * To inject sensitive data into your containers as environment variables,
                                      use the secrets container definition parameter.
 
-
                                      * To reference sensitive information in the log configuration of a container,
                                      use the secretOptions container definition parameter.
-
 
                                   For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                                   in the Amazon Elastic Container Service Developer Guide.
@@ -1217,9 +1232,7 @@ spec:
                                     Each alias ("endpoint") is a fully-qualified name and port number that other
                                     tasks ("clients") can use to connect to this service.
 
-
                                     Each name and port mapping must be unique within the namespace.
-
 
                                     Tasks that run in a namespace can use short names to connect to services
                                     in the namespace. Tasks can connect to services across all of the clusters
@@ -1246,7 +1259,6 @@ spec:
                               timeout:
                                 description: |-
                                   An object that represents the timeout configurations for Service Connect.
-
 
                                   If idleTimeout is set to a time that is less than perRequestTimeout, the
                                   connection will close when the idleTimeout is reached and not the perRequestTimeout.
@@ -1286,7 +1298,6 @@ spec:
                           Service Connect configuration for each discovery name of this Amazon ECS
                           service.
 
-
                           A task can resolve the dnsName for each of the clientAliases of a service.
                           However a task can't resolve the discovery names. If you want to connect
                           to a service, refer to the ServiceConnectConfiguration of that service for
@@ -1317,7 +1328,6 @@ spec:
                               The configuration for the Amazon EBS volume that Amazon ECS creates and manages
                               on your behalf. These settings are used to create each Amazon EBS volume,
                               with one volume created for each task in the service.
-
 
                               Many of these parameters map 1:1 with the Amazon EBS CreateVolume API request
                               parameters.
@@ -1353,31 +1363,23 @@ spec:
                                           The metadata that you apply to a resource to help you categorize and organize
                                           them. Each tag consists of a key and an optional value. You define them.
 
-
                                           The following basic restrictions apply to tags:
 
-
                                              * Maximum number of tags per resource - 50
-
 
                                              * For each resource, each tag key must be unique, and each tag key can
                                              have only one value.
 
-
                                              * Maximum key length - 128 Unicode characters in UTF-8
 
-
                                              * Maximum value length - 256 Unicode characters in UTF-8
-
 
                                              * If your tagging schema is used across multiple services and resources,
                                              remember that other services may have restrictions on allowed characters.
                                              Generally allowed characters are: letters, numbers, and spaces representable
                                              in UTF-8, and the following characters: + - = . _ : / @.
 
-
                                              * Tag keys and values are case-sensitive.
-
 
                                              * Do not use aws:, AWS:, or any upper or lowercase combination of such
                                              as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1430,7 +1432,6 @@ spec:
                   The operating system that your tasks in the service run on. A platform family
                   is specified only for tasks using the Fargate launch type.
 
-
                   All tasks that run as part of this service must use the same platformFamily
                   value as the service (for example, LINUX).
                 type: string
@@ -1469,23 +1470,19 @@ spec:
                           can be set when using the RunTask or CreateCluster APIs or as the default
                           capacity provider strategy for a cluster with the CreateCluster API.
 
-
                           Only capacity providers that are already associated with a cluster and have
                           an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                           The PutClusterCapacityProviders API is used to associate a capacity provider
                           with a cluster.
 
-
                           If specifying a capacity provider that uses an Auto Scaling group, the capacity
                           provider must already be created. New Auto Scaling group capacity providers
                           can be created with the CreateCapacityProvider API operation.
-
 
                           To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                           capacity providers. The Fargate capacity providers are available to all accounts
                           and only need to be associated with a cluster to be used in a capacity provider
                           strategy.
-
 
                           A capacity provider strategy may contain a maximum of 6 capacity providers.
                         properties:
@@ -1518,15 +1515,12 @@ spec:
                         description: |-
                           The load balancer configuration to use with a service or task set.
 
-
                           When you add, update, or remove a load balancer configuration, Amazon ECS
                           starts a new deployment with the updated Elastic Load Balancing configuration.
                           This causes tasks to register to and deregister from load balancers.
 
-
                           We recommend that you verify this on a test environment before you update
                           the Elastic Load Balancing configuration.
-
 
                           A service-linked role is required for services that use multiple target groups.
                           For more information, see Using service-linked roles (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
@@ -1539,8 +1533,36 @@ spec:
                             type: integer
                           loadBalancerName:
                             type: string
+                          loadBalancerRef:
+                            description: Reference field for LoadBalancerName
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
                           targetGroupARN:
                             type: string
+                          targetGroupRef:
+                            description: Reference field for TargetGroupARN
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
                         type: object
                       type: array
                     networkConfiguration:
@@ -1553,9 +1575,51 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1590,10 +1654,8 @@ spec:
                         description: |-
                           The details for the service registry.
 
-
                           Each service may be associated with one service registry. Multiple service
                           registries for each service are not supported.
-
 
                           When you add, update, or remove the service registries configuration, Amazon
                           ECS starts a new deployment. New tasks are registered and deregistered to
@@ -1626,31 +1688,23 @@ spec:
                           The metadata that you apply to a resource to help you categorize and organize
                           them. Each tag consists of a key and an optional value. You define them.
 
-
                           The following basic restrictions apply to tags:
 
-
                              * Maximum number of tags per resource - 50
-
 
                              * For each resource, each tag key must be unique, and each tag key can
                              have only one value.
 
-
                              * Maximum key length - 128 Unicode characters in UTF-8
 
-
                              * Maximum value length - 256 Unicode characters in UTF-8
-
 
                              * If your tagging schema is used across multiple services and resources,
                              remember that other services may have restrictions on allowed characters.
                              Generally allowed characters are: letters, numbers, and spaces representable
                              in UTF-8, and the following characters: + - = . _ : / @.
 
-
                              * Tag keys and values are case-sensitive.
-
 
                              * Do not use aws:, AWS:, or any upper or lowercase combination of such
                              as a prefix for either keys or values as it is reserved for Amazon Web

--- a/config/crd/bases/ecs.services.k8s.aws_taskdefinitions.yaml
+++ b/config/crd/bases/ecs.services.k8s.aws_taskdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: taskdefinitions.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -56,7 +56,6 @@ spec:
             description: |-
               TaskDefinitionSpec defines the desired state of TaskDefinition.
 
-
               The details of a task definition which describes the container and volume
               definitions of an Amazon Elastic Container Service task. You can specify
               which Docker images to use, the required resources, and other configurations
@@ -90,7 +89,6 @@ spec:
                           can contain multiple dependencies. When a dependency is defined for container
                           startup, for container shutdown it is reversed.
 
-
                           Your Amazon ECS container instances require at least version 1.26.0 of the
                           container agent to use container dependencies. However, we recommend using
                           the latest container agent version. For information about checking your agent
@@ -104,16 +102,12 @@ spec:
                           AMI (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
                           in the Amazon Elastic Container Service Developer Guide.
 
-
                           For tasks that use the Fargate launch type, the task or service requires
                           the following platforms:
 
-
                              * Linux platform version 1.3.0 or later.
 
-
                              * Windows platform version 1.0.0 or later.
-
 
                           For more information about how to create a container dependency, see Container
                           dependency (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_task_definitions.html#example_task_definition-containerdependency)
@@ -166,7 +160,6 @@ spec:
                           variable in VARIABLE=VALUE format. Lines beginning with # are treated as
                           comments and are ignored.
 
-
                           If there are environment variables specified using the environment parameter
                           in a container definition, they take precedence over the variables contained
                           within an environment file. If multiple environment files are specified that
@@ -175,24 +168,17 @@ spec:
                           environment variables (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html)
                           in the Amazon Elastic Container Service Developer Guide.
 
-
                           You must use the following platforms for the Fargate launch type:
-
 
                              * Linux platform version 1.4.0 or later.
 
-
                              * Windows platform version 1.0.0 or later.
-
 
                           Consider the following when using the Fargate launch type:
 
-
                              * The file is handled like a native Docker env-file.
 
-
                              * There is no support for shell escape handling.
-
 
                              * The container entry point interperts the VARIABLE values.
                         properties:
@@ -238,126 +224,96 @@ spec:
                         or from the image's Dockerfile). This configuration maps to the HEALTHCHECK
                         parameter of docker run (https://docs.docker.com/engine/reference/run/).
 
-
                         The Amazon ECS container agent only monitors and reports on the health checks
                         specified in the task definition. Amazon ECS does not monitor Docker health
                         checks that are embedded in a container image and not specified in the container
                         definition. Health check parameters that are specified in a container definition
                         override any Docker health checks that exist in the container image.
 
-
                         You can view the health status of both individual containers and a task with
                         the DescribeTasks API operation or when viewing the task details in the console.
-
 
                         The health check is designed to make sure that your containers survive agent
                         restarts, upgrades, or temporary unavailability.
 
-
                         The following describes the possible healthStatus values for a container:
-
 
                            * HEALTHY-The container health check has passed successfully.
 
-
                            * UNHEALTHY-The container health check has failed.
-
 
                            * UNKNOWN-The container health check is being evaluated, there's no container
                            health check defined, or Amazon ECS doesn't have the health status of
                            the container.
 
-
                         The following describes the possible healthStatus values based on the container
                         health checker status of essential containers in the task with the following
                         priority order (high to low):
 
-
                            * UNHEALTHY-One or more essential containers have failed their health
                            check.
-
 
                            * UNKNOWN-Any essential container running within the task is in an UNKNOWN
                            state and no other essential containers have an UNHEALTHY state.
 
-
                            * HEALTHY-All essential containers within the task have passed their health
                            checks.
 
-
                         Consider the following task health example with 2 containers.
-
 
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, the task health
                            is UNHEALTHY.
 
-
                            * If Container1 is UNHEALTHY and Container2 is HEALTHY, the task health
                            is UNHEALTHY.
-
 
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, the task health
                            is UNKNOWN.
 
-
                            * If Container1 is HEALTHY and Container2 is HEALTHY, the task health
                            is HEALTHY.
 
-
                         Consider the following task health example with 3 containers.
-
 
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, and Container3
                            is UNKNOWN, the task health is UNHEALTHY.
 
-
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, and Container3
                            is HEALTHY, the task health is UNHEALTHY.
-
 
                            * If Container1 is UNHEALTHY and Container2 is HEALTHY, and Container3
                            is HEALTHY, the task health is UNHEALTHY.
 
-
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, and Container3 is
                            HEALTHY, the task health is UNKNOWN.
-
 
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, and Container3 is
                            UNKNOWN, the task health is UNKNOWN.
 
-
                            * If Container1 is HEALTHY and Container2 is HEALTHY, and Container3 is
                            HEALTHY, the task health is HEALTHY.
-
 
                         If a task is run manually, and not as part of a service, the task will continue
                         its lifecycle regardless of its health status. For tasks that are part of
                         a service, if the task reports as unhealthy then the task will be stopped
                         and the service scheduler will replace it.
 
-
                         The following are notes about container health check support:
-
 
                            * When the Amazon ECS agent cannot connect to the Amazon ECS service,
                            the service reports the container as UNHEALTHY.
-
 
                            * The health check statuses are the "last heard from" response from the
                            Amazon ECS agent. There are no assumptions made about the status of the
                            container health checks.
 
-
                            * Container health checks require version 1.17.0 or greater of the Amazon
                            ECS container agent. For more information, see Updating the Amazon ECS
                            container agent (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html).
 
-
                            * Container health checks are supported for Fargate tasks if you're using
                            platform version 1.1.0 or greater. For more information, see Fargate platform
                            versions (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
-
 
                            * Container health checks aren't supported for tasks that are part of
                            a service that's configured to use a Classic Load Balancer.
@@ -463,7 +419,6 @@ spec:
                         section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                         and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                         By default, containers use the same logging driver that the Docker daemon
                         uses. However, the container might use a different logging driver than the
                         Docker daemon by specifying a log driver configuration in the container definition.
@@ -471,9 +426,7 @@ spec:
                         see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                         in the Docker documentation.
 
-
                         Understand the following when specifying a log configuration for your containers.
-
 
                            * Amazon ECS currently supports a subset of the logging drivers available
                            to the Docker daemon. Additional log drivers may be available in future
@@ -482,10 +435,8 @@ spec:
                            hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                            fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                            * This parameter requires version 1.18 of the Docker Remote API or greater
                            on your container instance.
-
 
                            * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                            agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -493,7 +444,6 @@ spec:
                            these log configuration options. For more information, see Amazon ECS
                            container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                            in the Amazon Elastic Container Service Developer Guide.
-
 
                            * For tasks that are on Fargate, because you don't have access to the
                            underlying infrastructure your tasks are hosted on, any additional software
@@ -513,14 +463,11 @@ spec:
                               An object representing the secret to expose to your container. Secrets can
                               be exposed to a container in the following ways:
 
-
                                  * To inject sensitive data into your containers as environment variables,
                                  use the secrets container definition parameter.
 
-
                                  * To reference sensitive information in the log configuration of a container,
                                  use the secretOptions container definition parameter.
-
 
                               For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                               in the Amazon Elastic Container Service Developer Guide.
@@ -560,11 +507,9 @@ spec:
                           to send or receive traffic. Port mappings are specified as part of the container
                           definition.
 
-
                           If you use containers in a task with the awsvpc or host network mode, specify
                           the exposed ports using containerPort. The hostPort can be left blank or
                           it must be the same value as the containerPort.
-
 
                           Most fields of this parameter (containerPort, hostPort, protocol) maps to
                           PortBindings in the Create a container (https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate)
@@ -573,10 +518,8 @@ spec:
                           If the network mode of a task definition is set to host, host ports must
                           either be undefined or match the container port in the port mapping.
 
-
                           You can't expose the same container port for multiple protocols. If you attempt
                           this, an error is returned.
-
 
                           After a task reaches the RUNNING status, manual and automatic host and container
                           port assignments are visible in the networkBindings section of DescribeTasks
@@ -632,14 +575,11 @@ spec:
                           An object representing the secret to expose to your container. Secrets can
                           be exposed to a container in the following ways:
 
-
                              * To inject sensitive data into your containers as environment variables,
                              use the secrets container definition parameter.
 
-
                              * To reference sensitive information in the log configuration of a container,
                              use the secretOptions container definition parameter.
-
 
                           For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                           in the Amazon Elastic Container Service Developer Guide.
@@ -666,11 +606,9 @@ spec:
                           For example, you can configure net.ipv4.tcp_keepalive_time setting to maintain
                           longer lived connections.
 
-
                           We don't recommend that you specify network-related systemControls parameters
                           for multiple containers in a single task that also uses either the awsvpc
                           or host network mode. Doing this has the following disadvantages:
-
 
                              * For tasks that use the awsvpc network mode including Fargate, if you
                              set systemControls for any container, it applies to all containers in
@@ -678,26 +616,20 @@ spec:
                              in a single task, the container that's started last determines which systemControls
                              take effect.
 
-
                              * For tasks that use the host network mode, the network namespace systemControls
                              aren't supported.
-
 
                           If you're setting an IPC resource namespace to use for the containers in
                           the task, the following conditions apply to your system controls. For more
                           information, see IPC mode (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_ipcmode).
 
-
                              * For tasks that use the host IPC mode, IPC namespace systemControls aren't
                              supported.
-
 
                              * For tasks that use the task IPC mode, IPC namespace systemControls values
                              apply to all containers within a task.
 
-
                           This parameter is not supported for Windows containers.
-
 
                           This parameter is only supported for tasks that are hosted on Fargate if
                           the tasks are using platform version 1.4.0 or later (Linux). This isn't supported
@@ -714,13 +646,11 @@ spec:
                         description: |-
                           The ulimit settings to pass to the container.
 
-
                           Amazon ECS tasks hosted on Fargate use the default resource limit values
                           set by the operating system with the exception of the nofile resource limit
                           parameter which Fargate overrides. The nofile resource limit sets a restriction
                           on the number of open files that a container can use. The default nofile
                           soft limit is 1024 and the default hard limit is 65535.
-
 
                           You can specify the ulimit settings for a container in a task definition.
                         properties:
@@ -758,48 +688,37 @@ spec:
                   1 vCPU or 1 vcpu) in a task definition. String values are converted to an
                   integer indicating the CPU units when the task definition is registered.
 
-
                   Task-level CPU and memory parameters are ignored for Windows containers.
                   We recommend specifying container-level resources for Windows containers.
-
 
                   If you're using the EC2 launch type, this field is optional. Supported values
                   are between 128 CPU units (0.125 vCPUs) and 10240 CPU units (10 vCPUs). If
                   you do not specify a value, the parameter is ignored.
 
-
                   If you're using the Fargate launch type, this field is required and you must
                   use one of the following values, which determines your range of supported
                   values for the memory parameter:
 
-
                   The CPU units cannot be less than 1 vCPU when you use Windows containers
                   on Fargate.
-
 
                      * 256 (.25 vCPU) - Available memory values: 512 (0.5 GB), 1024 (1 GB),
                      2048 (2 GB)
 
-
                      * 512 (.5 vCPU) - Available memory values: 1024 (1 GB), 2048 (2 GB), 3072
                      (3 GB), 4096 (4 GB)
-
 
                      * 1024 (1 vCPU) - Available memory values: 2048 (2 GB), 3072 (3 GB), 4096
                      (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB)
 
-
                      * 2048 (2 vCPU) - Available memory values: 4096 (4 GB) and 16384 (16 GB)
                      in increments of 1024 (1 GB)
-
 
                      * 4096 (4 vCPU) - Available memory values: 8192 (8 GB) and 30720 (30 GB)
                      in increments of 1024 (1 GB)
 
-
                      * 8192 (8 vCPU) - Available memory values: 16 GB and 60 GB in 4 GB increments
                      This option requires Linux platform 1.4.0 or later.
-
 
                      * 16384 (16vCPU) - Available memory values: 32GB and 120 GB in 8 GB increments
                      This option requires Linux platform 1.4.0 or later.
@@ -812,13 +731,10 @@ spec:
                   Using data volumes in tasks (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html)
                   in the Amazon ECS Developer Guide.
 
-
                   For tasks using the Fargate launch type, the task requires the following
                   platforms:
 
-
                      * Linux platform version 1.4.0 or later.
-
 
                      * Windows platform version 1.0.0 or later.
                 properties:
@@ -871,25 +787,20 @@ spec:
                   information, see IPC settings (https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)
                   in the Docker run reference.
 
-
                   If the host IPC mode is used, be aware that there is a heightened risk of
                   undesired IPC namespace expose. For more information, see Docker security
                   (https://docs.docker.com/engine/security/security/).
-
 
                   If you are setting namespaced kernel parameters using systemControls for
                   the containers in the task, the following will apply to your IPC resource
                   namespace. For more information, see System Controls (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                      * For tasks that use the host IPC mode, IPC namespace related systemControls
                      are not supported.
 
-
                      * For tasks that use the task IPC mode, IPC namespace related systemControls
                      will apply to all containers within a task.
-
 
                   This parameter is not supported for Windows containers or tasks run on Fargate.
                 type: string
@@ -900,46 +811,35 @@ spec:
                   1GB or 1 GB) in a task definition. String values are converted to an integer
                   indicating the MiB when the task definition is registered.
 
-
                   Task-level CPU and memory parameters are ignored for Windows containers.
                   We recommend specifying container-level resources for Windows containers.
 
-
                   If using the EC2 launch type, this field is optional.
-
 
                   If using the Fargate launch type, this field is required and you must use
                   one of the following values. This determines your range of supported values
                   for the cpu parameter.
 
-
                   The CPU units cannot be less than 1 vCPU when you use Windows containers
                   on Fargate.
-
 
                      * 512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25
                      vCPU)
 
-
                      * 1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values:
                      512 (.5 vCPU)
-
 
                      * 2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168
                      (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)
 
-
                      * Between 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) -
                      Available cpu values: 2048 (2 vCPU)
-
 
                      * Between 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) -
                      Available cpu values: 4096 (4 vCPU)
 
-
                      * Between 16 GB and 60 GB in 4 GB increments - Available cpu values: 8192
                      (8 vCPU) This option requires Linux platform 1.4.0 or later.
-
 
                      * Between 32GB and 120 GB in 8 GB increments - Available cpu values: 16384
                      (16 vCPU) This option requires Linux platform 1.4.0 or later.
@@ -950,7 +850,6 @@ spec:
                   values are none, bridge, awsvpc, and host. If no network mode is specified,
                   the default is bridge.
 
-
                   For Amazon ECS tasks on Fargate, the awsvpc network mode is required. For
                   Amazon ECS tasks on Amazon EC2 Linux instances, any network mode can be used.
                   For Amazon ECS tasks on Amazon EC2 Windows instances, <default> or awsvpc
@@ -960,16 +859,13 @@ spec:
                   networking performance for containers because they use the EC2 network stack
                   instead of the virtualized network stack provided by the bridge mode.
 
-
                   With the host and awsvpc network modes, exposed container ports are mapped
                   directly to the corresponding host port (for the host network mode) or the
                   attached elastic network interface port (for the awsvpc network mode), so
                   you cannot take advantage of dynamic host port mappings.
 
-
                   When using the host network mode, you should not run containers using the
                   root user (UID 0). It is considered best practice to use a non-root user.
-
 
                   If the network mode is awsvpc, the task is allocated an elastic network interface,
                   and you must specify a NetworkConfiguration value when you create a service
@@ -977,10 +873,8 @@ spec:
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   If the network mode is host, you cannot run multiple instantiations of the
                   same task on a single container instance when port mappings are used.
-
 
                   For more information, see Network settings (https://docs.docker.com/engine/reference/run/#network-settings)
                   in the Docker run reference.
@@ -992,27 +886,21 @@ spec:
                   task. For example, monitoring sidecars might need pidMode to access information
                   about other containers running in the same task.
 
-
                   If host is specified, all containers within the tasks that specified the
                   host PID mode on the same container instance share the same process namespace
                   with the host Amazon EC2 instance.
 
-
                   If task is specified, all containers within the specified task share the
                   same process namespace.
-
 
                   If no value is specified, the default is a private namespace for each container.
                   For more information, see PID settings (https://docs.docker.com/engine/reference/run/#pid-settings---pid)
                   in the Docker run reference.
 
-
                   If the host PID mode is used, there's a heightened risk of undesired process
                   namespace exposure. For more information, see Docker security (https://docs.docker.com/engine/security/security/).
 
-
                   This parameter is not supported for Windows containers.
-
 
                   This parameter is only supported for tasks that are hosted on Fargate if
                   the tasks are using platform version 1.4.0 or later (Linux). This isn't supported
@@ -1029,7 +917,6 @@ spec:
                     see Task placement constraints (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
                     in the Amazon Elastic Container Service Developer Guide.
 
-
                     Task placement constraints aren't supported for tasks run on Fargate.
                   properties:
                     expression:
@@ -1041,7 +928,6 @@ spec:
               proxyConfiguration:
                 description: |-
                   The configuration details for the App Mesh proxy.
-
 
                   For tasks hosted on Amazon EC2 instances, the container instances require
                   at least version 1.26.0 of the container agent and at least version 1.26.0-1
@@ -1080,7 +966,6 @@ spec:
                   The operating system that your tasks definitions run on. A platform family
                   is specified only for tasks using the Fargate launch type.
 
-
                   When you specify a task definition in a service, this value must match the
                   runtimePlatform value of the service.
                 properties:
@@ -1095,31 +980,23 @@ spec:
                   and organize them. Each tag consists of a key and an optional value. You
                   define both of them.
 
-
                   The following basic restrictions apply to tags:
 
-
                      * Maximum number of tags per resource - 50
-
 
                      * For each resource, each tag key must be unique, and each tag key can
                      have only one value.
 
-
                      * Maximum key length - 128 Unicode characters in UTF-8
 
-
                      * Maximum value length - 256 Unicode characters in UTF-8
-
 
                      * If your tagging schema is used across multiple services and resources,
                      remember that other services may have restrictions on allowed characters.
                      Generally allowed characters are: letters, numbers, and spaces representable
                      in UTF-8, and the following characters: + - = . _ : / @.
 
-
                      * Tag keys and values are case-sensitive.
-
 
                      * Do not use aws:, AWS:, or any upper or lowercase combination of such
                      as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1130,31 +1007,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                        * Maximum number of tags per resource - 50
-
 
                        * For each resource, each tag key must be unique, and each tag key can
                        have only one value.
 
-
                        * Maximum key length - 128 Unicode characters in UTF-8
 
-
                        * Maximum value length - 256 Unicode characters in UTF-8
-
 
                        * If your tagging schema is used across multiple services and resources,
                        remember that other services may have restrictions on allowed characters.
                        Generally allowed characters are: letters, numbers, and spaces representable
                        in UTF-8, and the following characters: + - = . _ : / @.
 
-
                        * Tag keys and values are case-sensitive.
-
 
                        * Do not use aws:, AWS:, or any upper or lowercase combination of such
                        as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1178,7 +1047,7 @@ spec:
               taskRoleRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -1263,7 +1132,6 @@ spec:
                         Server (https://docs.aws.amazon.com/fsx/latest/WindowsGuide/what-is.html)
                         file system for task storage.
 
-
                         For more information and the input format, see Amazon FSx for Windows File
                         Server volumes (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/wfsx-volumes.html)
                         in the Amazon Elastic Container Service Developer Guide.
@@ -1273,7 +1141,6 @@ spec:
                             The authorization configuration details for Amazon FSx for Windows File Server
                             file system. See FSxWindowsFileServerVolumeConfiguration (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FSxWindowsFileServerVolumeConfiguration.html)
                             in the Amazon ECS API Reference.
-
 
                             For more information and the input format, see Amazon FSx for Windows File
                             Server Volumes (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/wfsx-volumes.html)
@@ -1321,7 +1188,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -1403,7 +1269,6 @@ spec:
                   for tasks hosted on Amazon EC2 instances. For more information, see Attributes
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   This parameter isn't supported for tasks run on Fargate.
                 items:

--- a/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
+++ b/config/crd/common/bases/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws
@@ -78,10 +78,8 @@ spec:
                       automatically converts this to an arbitrary string-string map.
                       https://github.com/kubernetes-sigs/controller-tools/issues/385
 
-
                       Active discussion about inclusion of this field in the spec is happening in this PR:
                       https://github.com/kubernetes-sigs/controller-tools/pull/395
-
 
                       Until this is allowed, or if it never is, we will produce a subset of the object meta
                       that contains only the fields which the user is allowed to modify in the metadata.
@@ -105,12 +103,10 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
-
 
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
@@ -139,7 +135,6 @@ spec:
                           equivalent to the "default" namespace, but "default" is the canonical representation.
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
-
 
                           Must be a DNS_LABEL.
                           Cannot be updated.

--- a/config/crd/common/bases/services.k8s.aws_fieldexports.yaml
+++ b/config/crd/common/bases/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list
@@ -22,57 +23,20 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
+  - ec2.services.k8s.aws
   resources:
-  - secrets
+  - securitygroups
+  - securitygroups/status
+  - subnets
+  - subnets/status
   verbs:
   - get
   - list
-  - patch
-  - watch
 - apiGroups:
   - ecs.services.k8s.aws
   resources:
   - clusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
-  - clusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
   - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
-  - services/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
   - taskdefinitions
   verbs:
   - create
@@ -85,21 +49,27 @@ rules:
 - apiGroups:
   - ecs.services.k8s.aws
   resources:
+  - clusters/status
+  - services/status
   - taskdefinitions/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - iam.services.k8s.aws
+  - elbv2.services.k8s.aws
   resources:
-  - roles
+  - loadbalancers
+  - loadbalancers/status
+  - targetgroups
+  - targetgroups/status
   verbs:
   - get
   - list
 - apiGroups:
   - iam.services.k8s.aws
   resources:
+  - roles
   - roles/status
   verbs:
   - get
@@ -108,25 +78,6 @@ rules:
   - services.k8s.aws
   resources:
   - adoptedresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - services.k8s.aws
-  resources:
-  - adoptedresources/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - services.k8s.aws
-  resources:
   - fieldexports
   verbs:
   - create
@@ -139,6 +90,7 @@ rules:
 - apiGroups:
   - services.k8s.aws
   resources:
+  - adoptedresources/status
   - fieldexports/status
   verbs:
   - get

--- a/generator.yaml
+++ b/generator.yaml
@@ -187,6 +187,26 @@ resources:
           path: Status.ACKResourceMetadata.ARN
           resource: Role
           service_name: iam
+      LoadBalancers.LoadBalancerName:
+        references:
+          path: Spec.Name
+          resource: LoadBalancer
+          service_name: elbv2
+      LoadBalancers.TargetGroupArn:
+        references:
+          path: Status.ACKResourceMetadata.ARN
+          resource: TargetGroup
+          service_name: elbv2
+      NetworkConfiguration.AwsvpcConfiguration.Subnets:
+        references:
+          path: Status.SubnetID
+          resource: Subnet
+          service_name: ec2
+      NetworkConfiguration.AwsvpcConfiguration.SecurityGroups:
+        references:
+          path: Status.ID
+          resource: SecurityGroup
+          service_name: ec2
     list_operation:
       match_fields:
       - Name

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
+	github.com/aws-controllers-k8s/ec2-controller v1.2.26
+	github.com/aws-controllers-k8s/elbv2-controller v1.0.0
 	github.com/aws-controllers-k8s/iam-controller v1.3.4
 	github.com/aws-controllers-k8s/runtime v0.38.0
 	github.com/aws/aws-sdk-go v1.50.20

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/aws-controllers-k8s/ec2-controller v1.2.26 h1:qv4mP5ktKx6xNwLqT6IMf755w47bpRQH7AbnwOVYZ10=
+github.com/aws-controllers-k8s/ec2-controller v1.2.26/go.mod h1:ZmMq9XXSr9eIsh9ERBRJ4s8wOak8dm4h5PEQLsxbCTE=
+github.com/aws-controllers-k8s/elbv2-controller v1.0.0 h1:PbtYHf/Fmd9AghPV7TynPZYNiMDYyGTFNOjvvrzjavs=
+github.com/aws-controllers-k8s/elbv2-controller v1.0.0/go.mod h1:yJ7ajoT/UdDddD2lMq3bAjZZqHplqUFwnLDj2VLnLiU=
 github.com/aws-controllers-k8s/iam-controller v1.3.4 h1:C/CgvJQb6I6mtjgV10FtyWq81S6IhNG+dF4+mjxANEY=
 github.com/aws-controllers-k8s/iam-controller v1.3.4/go.mod h1:8S4IXeK3Y9HABtSwy0Y8X/iBmBH1L/ab1D1cZ0YVlg0=
 github.com/aws-controllers-k8s/runtime v0.38.0 h1:gSEpmBm7OwTPd2kIOU+AIDIivi3teSm5FFrhROfu4wg=

--- a/helm/crds/ecs.services.k8s.aws_clusters.yaml
+++ b/helm/crds/ecs.services.k8s.aws_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: clusters.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -56,7 +56,6 @@ spec:
             description: |-
               ClusterSpec defines the desired state of Cluster.
 
-
               A regional grouping of one or more container instances where you can run
               task requests. Each account receives a default cluster the first time you
               use the Amazon ECS service, but you may also create other clusters. Clusters
@@ -71,18 +70,15 @@ spec:
                   or RunTask (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html)
                   actions.
 
-
                   If specifying a capacity provider that uses an Auto Scaling group, the capacity
                   provider must be created but not associated with another cluster. New Auto
                   Scaling group capacity providers can be created with the CreateCapacityProvider
                   (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCapacityProvider.html)
                   API operation.
 
-
                   To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                   capacity providers. The Fargate capacity providers are available to all accounts
                   and only need to be associated with a cluster to be used.
-
 
                   The PutCapacityProvider (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutCapacityProvider.html)
                   API operation is used to update the list of available capacity providers
@@ -127,7 +123,6 @@ spec:
                   APIs with no capacity provider strategy or launch type specified, the default
                   capacity provider strategy for the cluster is used.
 
-
                   If a default capacity provider strategy isn't defined for a cluster when
                   it was created, it can be defined later with the PutClusterCapacityProviders
                   API operation.
@@ -137,23 +132,19 @@ spec:
                     can be set when using the RunTask or CreateCluster APIs or as the default
                     capacity provider strategy for a cluster with the CreateCluster API.
 
-
                     Only capacity providers that are already associated with a cluster and have
                     an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                     The PutClusterCapacityProviders API is used to associate a capacity provider
                     with a cluster.
 
-
                     If specifying a capacity provider that uses an Auto Scaling group, the capacity
                     provider must already be created. New Auto Scaling group capacity providers
                     can be created with the CreateCapacityProvider API operation.
-
 
                     To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                     capacity providers. The Fargate capacity providers are available to all accounts
                     and only need to be associated with a cluster to be used in a capacity provider
                     strategy.
-
 
                     A capacity provider strategy may contain a maximum of 6 capacity providers.
                   properties:
@@ -182,7 +173,6 @@ spec:
                   parameter to true in the ServiceConnectConfiguration. You can set the namespace
                   of each service individually in the ServiceConnectConfiguration to override
                   this default parameter.
-
 
                   Tasks that run in a namespace can use short names to connect to services
                   in the namespace. Tasks can connect to services across all of the clusters
@@ -216,31 +206,23 @@ spec:
                   The metadata that you apply to the cluster to help you categorize and organize
                   them. Each tag consists of a key and an optional value. You define both.
 
-
                   The following basic restrictions apply to tags:
 
-
                     - Maximum number of tags per resource - 50
-
 
                     - For each resource, each tag key must be unique, and each tag key can
                       have only one value.
 
-
                     - Maximum key length - 128 Unicode characters in UTF-8
 
-
                     - Maximum value length - 256 Unicode characters in UTF-8
-
 
                     - If your tagging schema is used across multiple services and resources,
                       remember that other services may have restrictions on allowed characters.
                       Generally allowed characters are: letters, numbers, and spaces representable
                       in UTF-8, and the following characters: + - = . _ : / @.
 
-
                     - Tag keys and values are case-sensitive.
-
 
                     - Do not use aws:, AWS:, or any upper or lowercase combination of such
                       as a prefix for either keys or values as it is reserved for Amazon Web
@@ -251,31 +233,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                       - Maximum number of tags per resource - 50
-
 
                       - For each resource, each tag key must be unique, and each tag key can
                         have only one value.
 
-
                       - Maximum key length - 128 Unicode characters in UTF-8
 
-
                       - Maximum value length - 256 Unicode characters in UTF-8
-
 
                       - If your tagging schema is used across multiple services and resources,
                         remember that other services may have restrictions on allowed characters.
                         Generally allowed characters are: letters, numbers, and spaces representable
                         in UTF-8, and the following characters: + - = . _ : / @.
 
-
                       - Tag keys and values are case-sensitive.
-
 
                       - Do not use aws:, AWS:, or any upper or lowercase combination of such
                         as a prefix for either keys or values as it is reserved for Amazon Web
@@ -306,7 +280,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -360,21 +333,15 @@ spec:
                   The status of the capacity providers associated with the cluster. The following
                   are the states that are returned.
 
-
                   UPDATE_IN_PROGRESS
-
 
                   The available capacity providers for the cluster are updating.
 
-
                   UPDATE_COMPLETE
-
 
                   The capacity providers have successfully updated.
 
-
                   UPDATE_FAILED
-
 
                   The capacity provider updates failed.
                 type: string
@@ -434,27 +401,19 @@ spec:
                   Additional information about your clusters that are separated by launch type.
                   They include the following:
 
-
                      * runningEC2TasksCount
-
 
                      * RunningFargateTasksCount
 
-
                      * pendingEC2TasksCount
-
 
                      * pendingFargateTasksCount
 
-
                      * activeEC2ServiceCount
-
 
                      * activeFargateServiceCount
 
-
                      * drainingEC2ServiceCount
-
 
                      * drainingFargateServiceCount
                 items:
@@ -471,37 +430,27 @@ spec:
                   The status of the cluster. The following are the possible states that are
                   returned.
 
-
                   ACTIVE
-
 
                   The cluster is ready to accept tasks and if applicable you can register container
                   instances with the cluster.
 
-
                   PROVISIONING
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider are being created.
 
-
                   DEPROVISIONING
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider are being deleted.
 
-
                   FAILED
-
 
                   The cluster has capacity providers that are associated with it and the resources
                   needed for the capacity provider have failed to create.
 
-
                   INACTIVE
-
 
                   The cluster has been deleted. Clusters with an INACTIVE status may remain
                   discoverable in your account for a period of time. However, this behavior

--- a/helm/crds/ecs.services.k8s.aws_services.yaml
+++ b/helm/crds/ecs.services.k8s.aws_services.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: services.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -62,18 +62,15 @@ spec:
             description: |-
               ServiceSpec defines the desired state of Service.
 
-
               Details on a service within a cluster.
             properties:
               capacityProviderStrategy:
                 description: |-
                   The capacity provider strategy to use for the service.
 
-
                   If a capacityProviderStrategy is specified, the launchType parameter must
                   be omitted. If no capacityProviderStrategy or launchType is specified, the
                   defaultCapacityProviderStrategy for the cluster is used.
-
 
                   A capacity provider strategy may contain a maximum of 6 capacity providers.
                 items:
@@ -82,23 +79,19 @@ spec:
                     can be set when using the RunTask or CreateCluster APIs or as the default
                     capacity provider strategy for a cluster with the CreateCluster API.
 
-
                     Only capacity providers that are already associated with a cluster and have
                     an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                     The PutClusterCapacityProviders API is used to associate a capacity provider
                     with a cluster.
 
-
                     If specifying a capacity provider that uses an Auto Scaling group, the capacity
                     provider must already be created. New Auto Scaling group capacity providers
                     can be created with the CreateCapacityProvider API operation.
-
 
                     To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                     capacity providers. The Fargate capacity providers are available to all accounts
                     and only need to be associated with a cluster to be used in a capacity provider
                     strategy.
-
 
                     A capacity provider strategy may contain a maximum of 6 capacity providers.
                   properties:
@@ -121,7 +114,7 @@ spec:
               clusterRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -146,15 +139,12 @@ spec:
                       deployment has failed, and then to optionally roll back the failure to the
                       last working deployment.
 
-
                       When the alarms are generated, Amazon ECS sets the service deployment to
                       failed. Set the rollback parameter to have Amazon ECS to roll back your service
                       to the last completed deployment after a failure.
 
-
                       You can only use the DeploymentAlarms method to detect failures when the
                       DeploymentController is set to ECS (rolling update).
-
 
                       For more information, see Rolling update (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html)
                       in the Amazon Elastic Container Service Developer Guide .
@@ -173,14 +163,12 @@ spec:
                       The deployment circuit breaker can only be used for services using the rolling
                       update (ECS) deployment type.
 
-
                       The deployment circuit breaker determines whether a service deployment will
                       fail if the service can't reach a steady state. If it is turned on, a service
                       deployment will transition to a failed state and stop launching new tasks.
                       You can also configure Amazon ECS to roll back your service to the last completed
                       deployment after a failure. For more information, see Rolling update (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html)
                       in the Amazon Elastic Container Service Developer Guide.
-
 
                       For more information about API failure reasons, see API failure reasons (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/api_failures_messages.html)
                       in the Amazon Elastic Container Service Developer Guide.
@@ -210,7 +198,6 @@ spec:
                   The number of instantiations of the specified task definition to place and
                   keep running in your service.
 
-
                   This is required if schedulingStrategy is REPLICA or isn't specified. If
                   schedulingStrategy is DAEMON then this isn't required.
                 format: int64
@@ -221,7 +208,6 @@ spec:
                   the service. For more information, see Tagging your Amazon ECS resources
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   When you use Amazon ECS managed tags, you need to set the propagateTags request
                   parameter.
@@ -240,11 +226,9 @@ spec:
                   balancer. If your service has a load balancer defined and you don't specify
                   a health check grace period value, the default value of 0 is used.
 
-
                   If you do not use an Elastic Load Balancing, we recommend that you use the
                   startPeriod in the task definition health check parameters. For more information,
                   see Health check (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_HealthCheck.html).
-
 
                   If your service's tasks take a while to start and respond to Elastic Load
                   Balancing health checks, you can specify a health check grace period of up
@@ -260,23 +244,18 @@ spec:
                   Amazon ECS launch types (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   The FARGATE launch type runs your tasks on Fargate On-Demand infrastructure.
-
 
                   Fargate Spot infrastructure is available for use but a capacity provider
                   strategy must be used. For more information, see Fargate capacity providers
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-capacity-providers.html)
                   in the Amazon ECS User Guide for Fargate.
 
-
                   The EC2 launch type runs your tasks on Amazon EC2 instances registered to
                   your cluster.
 
-
                   The EXTERNAL launch type runs your tasks on your on-premises server or virtual
                   machine (VM) capacity registered to your cluster.
-
 
                   A service can use either a launch type or a capacity provider strategy. If
                   a launchType is specified, the capacityProviderStrategy parameter must be
@@ -288,14 +267,12 @@ spec:
                   For more information, see Service load balancing (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   If the service uses the rolling update (ECS) deployment controller and using
                   either an Application Load Balancer or Network Load Balancer, you must specify
                   one or more target group ARNs to attach to the service. The service-linked
                   role is required for services that use multiple target groups. For more information,
                   see Using service-linked roles for Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   If the service uses the CODE_DEPLOY deployment controller, the service is
                   required to use either an Application Load Balancer or Network Load Balancer.
@@ -308,10 +285,8 @@ spec:
                   that you can use to perform validation tests with Lambda functions before
                   routing production traffic to it.
 
-
                   If you use the CODE_DEPLOY deployment controller, these values can be changed
                   when updating the service.
-
 
                   For Application Load Balancers and Network Load Balancers, this object must
                   contain the load balancer target group ARN, the container name, and the container
@@ -321,14 +296,12 @@ spec:
                   instance and port combination is registered as a target in the target group
                   that's specified here.
 
-
                   For Classic Load Balancers, this object must contain the load balancer name,
                   the container name , and the container port to access from the load balancer.
                   The container name must be as it appears in a container definition. The target
                   group ARN parameter must be omitted. When a task from this service is placed
                   on a container instance, the container instance is registered with the load
                   balancer that's specified here.
-
 
                   Services with tasks that use the awsvpc network mode (for example, those
                   with the Fargate launch type) only support Application Load Balancers and
@@ -341,15 +314,12 @@ spec:
                   description: |-
                     The load balancer configuration to use with a service or task set.
 
-
                     When you add, update, or remove a load balancer configuration, Amazon ECS
                     starts a new deployment with the updated Elastic Load Balancing configuration.
                     This causes tasks to register to and deregister from load balancers.
 
-
                     We recommend that you verify this on a test environment before you update
                     the Elastic Load Balancing configuration.
-
 
                     A service-linked role is required for services that use multiple target groups.
                     For more information, see Using service-linked roles (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
@@ -362,8 +332,36 @@ spec:
                       type: integer
                     loadBalancerName:
                       type: string
+                    loadBalancerRef:
+                      description: Reference field for LoadBalancerName
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                     targetGroupARN:
                       type: string
+                    targetGroupRef:
+                      description: Reference field for TargetGroupARN
+                      properties:
+                        from:
+                          description: |-
+                            AWSResourceReference provides all the values necessary to reference another
+                            k8s resource for finding the identifier(Id/ARN/Name)
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 type: array
               name:
@@ -388,9 +386,49 @@ spec:
                     properties:
                       assignPublicIP:
                         type: string
+                      securityGroupRefs:
+                        description: Reference field for SecurityGroups
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
                       securityGroups:
                         items:
                           type: string
+                        type: array
+                      subnetRefs:
+                        description: Reference field for Subnets
+                        items:
+                          description: "AWSResourceReferenceWrapper provides a wrapper
+                            around *AWSResourceReference\ntype to provide more user
+                            friendly syntax for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                            \ name: my-api"
+                          properties:
+                            from:
+                              description: |-
+                                AWSResourceReference provides all the values necessary to reference another
+                                k8s resource for finding the identifier(Id/ARN/Name)
+                              properties:
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                          type: object
                         type: array
                       subnets:
                         items:
@@ -408,7 +446,6 @@ spec:
                     An object representing a constraint on task placement. For more information,
                     see Task placement constraints (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
                     in the Amazon Elastic Container Service Developer Guide.
-
 
                     If you're using the Fargate launch type, task placement constraints aren't
                     supported.
@@ -451,7 +488,6 @@ spec:
                   use the TagResource (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_TagResource.html)
                   API action.
 
-
                   The default is NONE.
                 type: string
               role:
@@ -463,7 +499,6 @@ spec:
                   parameter, you must also specify a load balancer object with the loadBalancers
                   parameter.
 
-
                   If your account has already created the Amazon ECS service-linked role, that
                   role is used for your service unless you specify a role here. The service-linked
                   role is required if your task definition uses the awsvpc network mode or
@@ -472,7 +507,6 @@ spec:
                   which case you don't specify a role here. For more information, see Using
                   service-linked roles for Amazon ECS (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   If your specified role has a path other than /, then you must either specify
                   the full role ARN (this is recommended) or prefix the role name with the
@@ -484,7 +518,7 @@ spec:
               roleRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -503,9 +537,7 @@ spec:
                   The scheduling strategy to use for the service. For more information, see
                   Services (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html).
 
-
                   There are two service scheduler strategies available:
-
 
                     - REPLICA-The replica scheduling strategy places and maintains the desired
                       number of tasks across your cluster. By default, the service scheduler
@@ -513,7 +545,6 @@ spec:
                       and constraints to customize task placement decisions. This scheduler
                       strategy is required if the service uses the CODE_DEPLOY or EXTERNAL deployment
                       controller types.
-
 
                     - DAEMON-The daemon scheduling strategy deploys exactly one task on each
                       active container instance that meets all of the task placement constraints
@@ -529,7 +560,6 @@ spec:
                 description: |-
                   The configuration for this service to discover and connect to services, and
                   be discovered by, and connected from, other services within a namespace.
-
 
                   Tasks that run in a namespace can use short names to connect to services
                   in the namespace. Tasks can connect to services across all of the clusters
@@ -548,7 +578,6 @@ spec:
                       section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                       and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                       By default, containers use the same logging driver that the Docker daemon
                       uses. However, the container might use a different logging driver than the
                       Docker daemon by specifying a log driver configuration in the container definition.
@@ -556,9 +585,7 @@ spec:
                       see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                       in the Docker documentation.
 
-
                       Understand the following when specifying a log configuration for your containers.
-
 
                          * Amazon ECS currently supports a subset of the logging drivers available
                          to the Docker daemon. Additional log drivers may be available in future
@@ -567,10 +594,8 @@ spec:
                          hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                          fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                          * This parameter requires version 1.18 of the Docker Remote API or greater
                          on your container instance.
-
 
                          * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                          agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -578,7 +603,6 @@ spec:
                          these log configuration options. For more information, see Amazon ECS
                          container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                          in the Amazon Elastic Container Service Developer Guide.
-
 
                          * For tasks that are on Fargate, because you don't have access to the
                          underlying infrastructure your tasks are hosted on, any additional software
@@ -598,14 +622,11 @@ spec:
                             An object representing the secret to expose to your container. Secrets can
                             be exposed to a container in the following ways:
 
-
                               - To inject sensitive data into your containers as environment variables,
                                 use the secrets container definition parameter.
 
-
                               - To reference sensitive information in the log configuration of a container,
                                 use the secretOptions container definition parameter.
-
 
                             For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                             in the Amazon Elastic Container Service Developer Guide.
@@ -632,9 +653,7 @@ spec:
                               Each alias ("endpoint") is a fully-qualified name and port number that other
                               tasks ("clients") can use to connect to this service.
 
-
                               Each name and port mapping must be unique within the namespace.
-
 
                               Tasks that run in a namespace can use short names to connect to services
                               in the namespace. Tasks can connect to services across all of the clusters
@@ -661,7 +680,6 @@ spec:
                         timeout:
                           description: |-
                             An object that represents the timeout configurations for Service Connect.
-
 
                             If idleTimeout is set to a time that is less than perRequestTimeout, the
                             connection will close when the idleTimeout is reached and not the perRequestTimeout.
@@ -698,17 +716,14 @@ spec:
                   The details of the service discovery registry to associate with this service.
                   For more information, see Service discovery (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html).
 
-
                   Each service may be associated with one service registry. Multiple service
                   registries for each service isn't supported.
                 items:
                   description: |-
                     The details for the service registry.
 
-
                     Each service may be associated with one service registry. Multiple service
                     registries for each service are not supported.
-
 
                     When you add, update, or remove the service registries configuration, Amazon
                     ECS starts a new deployment. New tasks are registered and deregistered to
@@ -732,31 +747,23 @@ spec:
                   them. Each tag consists of a key and an optional value, both of which you
                   define. When a service is deleted, the tags are deleted as well.
 
-
                   The following basic restrictions apply to tags:
 
-
                     - Maximum number of tags per resource - 50
-
 
                     - For each resource, each tag key must be unique, and each tag key can
                       have only one value.
 
-
                     - Maximum key length - 128 Unicode characters in UTF-8
 
-
                     - Maximum value length - 256 Unicode characters in UTF-8
-
 
                     - If your tagging schema is used across multiple services and resources,
                       remember that other services may have restrictions on allowed characters.
                       Generally allowed characters are: letters, numbers, and spaces representable
                       in UTF-8, and the following characters: + - = . _ : / @.
 
-
                     - Tag keys and values are case-sensitive.
-
 
                     - Do not use aws:, AWS:, or any upper or lowercase combination of such
                       as a prefix for either keys or values as it is reserved for Amazon Web
@@ -767,31 +774,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                       - Maximum number of tags per resource - 50
-
 
                       - For each resource, each tag key must be unique, and each tag key can
                         have only one value.
 
-
                       - Maximum key length - 128 Unicode characters in UTF-8
 
-
                       - Maximum value length - 256 Unicode characters in UTF-8
-
 
                       - If your tagging schema is used across multiple services and resources,
                         remember that other services may have restrictions on allowed characters.
                         Generally allowed characters are: letters, numbers, and spaces representable
                         in UTF-8, and the following characters: + - = . _ : / @.
 
-
                       - Tag keys and values are case-sensitive.
-
 
                       - Do not use aws:, AWS:, or any upper or lowercase combination of such
                         as a prefix for either keys or values as it is reserved for Amazon Web
@@ -810,10 +809,8 @@ spec:
                   to run in your service. If a revision isn't specified, the latest ACTIVE
                   revision is used.
 
-
                   A task definition must be specified if the service uses either the ECS or
                   CODE_DEPLOY deployment controllers.
-
 
                   For more information about deployment types, see Amazon ECS deployment types
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-types.html).
@@ -821,7 +818,7 @@ spec:
               taskDefinitionRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -851,7 +848,6 @@ spec:
                         The configuration for the Amazon EBS volume that Amazon ECS creates and manages
                         on your behalf. These settings are used to create each Amazon EBS volume,
                         with one volume created for each task in the service.
-
 
                         Many of these parameters map 1:1 with the Amazon EBS CreateVolume API request
                         parameters.
@@ -886,31 +882,23 @@ spec:
                                     The metadata that you apply to a resource to help you categorize and organize
                                     them. Each tag consists of a key and an optional value. You define them.
 
-
                                     The following basic restrictions apply to tags:
 
-
                                       - Maximum number of tags per resource - 50
-
 
                                       - For each resource, each tag key must be unique, and each tag key can
                                         have only one value.
 
-
                                       - Maximum key length - 128 Unicode characters in UTF-8
 
-
                                       - Maximum value length - 256 Unicode characters in UTF-8
-
 
                                       - If your tagging schema is used across multiple services and resources,
                                         remember that other services may have restrictions on allowed characters.
                                         Generally allowed characters are: letters, numbers, and spaces representable
                                         in UTF-8, and the following characters: + - = . _ : / @.
 
-
                                       - Tag keys and values are case-sensitive.
-
 
                                       - Do not use aws:, AWS:, or any upper or lowercase combination of such
                                         as a prefix for either keys or values as it is reserved for Amazon Web
@@ -955,7 +943,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -1032,23 +1019,19 @@ spec:
                           can be set when using the RunTask or CreateCluster APIs or as the default
                           capacity provider strategy for a cluster with the CreateCluster API.
 
-
                           Only capacity providers that are already associated with a cluster and have
                           an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                           The PutClusterCapacityProviders API is used to associate a capacity provider
                           with a cluster.
 
-
                           If specifying a capacity provider that uses an Auto Scaling group, the capacity
                           provider must already be created. New Auto Scaling group capacity providers
                           can be created with the CreateCapacityProvider API operation.
-
 
                           To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                           capacity providers. The Fargate capacity providers are available to all accounts
                           and only need to be associated with a cluster to be used in a capacity provider
                           strategy.
-
 
                           A capacity provider strategy may contain a maximum of 6 capacity providers.
                         properties:
@@ -1085,9 +1068,51 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1115,7 +1140,6 @@ spec:
                         for this service to discover and connect to services, and be discovered by,
                         and connected from, other services within a namespace.
 
-
                         Tasks that run in a namespace can use short names to connect to services
                         in the namespace. Tasks can connect to services across all of the clusters
                         in the namespace. Tasks connect through a managed proxy container that collects
@@ -1133,7 +1157,6 @@ spec:
                             section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                             and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                             By default, containers use the same logging driver that the Docker daemon
                             uses. However, the container might use a different logging driver than the
                             Docker daemon by specifying a log driver configuration in the container definition.
@@ -1141,9 +1164,7 @@ spec:
                             see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                             in the Docker documentation.
 
-
                             Understand the following when specifying a log configuration for your containers.
-
 
                                * Amazon ECS currently supports a subset of the logging drivers available
                                to the Docker daemon. Additional log drivers may be available in future
@@ -1152,10 +1173,8 @@ spec:
                                hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                                fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                                * This parameter requires version 1.18 of the Docker Remote API or greater
                                on your container instance.
-
 
                                * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                                agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -1163,7 +1182,6 @@ spec:
                                these log configuration options. For more information, see Amazon ECS
                                container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                                in the Amazon Elastic Container Service Developer Guide.
-
 
                                * For tasks that are on Fargate, because you don't have access to the
                                underlying infrastructure your tasks are hosted on, any additional software
@@ -1183,14 +1201,11 @@ spec:
                                   An object representing the secret to expose to your container. Secrets can
                                   be exposed to a container in the following ways:
 
-
                                     - To inject sensitive data into your containers as environment variables,
                                       use the secrets container definition parameter.
 
-
                                     - To reference sensitive information in the log configuration of a container,
                                       use the secretOptions container definition parameter.
-
 
                                   For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                                   in the Amazon Elastic Container Service Developer Guide.
@@ -1217,9 +1232,7 @@ spec:
                                     Each alias ("endpoint") is a fully-qualified name and port number that other
                                     tasks ("clients") can use to connect to this service.
 
-
                                     Each name and port mapping must be unique within the namespace.
-
 
                                     Tasks that run in a namespace can use short names to connect to services
                                     in the namespace. Tasks can connect to services across all of the clusters
@@ -1246,7 +1259,6 @@ spec:
                               timeout:
                                 description: |-
                                   An object that represents the timeout configurations for Service Connect.
-
 
                                   If idleTimeout is set to a time that is less than perRequestTimeout, the
                                   connection will close when the idleTimeout is reached and not the perRequestTimeout.
@@ -1286,7 +1298,6 @@ spec:
                           Service Connect configuration for each discovery name of this Amazon ECS
                           service.
 
-
                           A task can resolve the dnsName for each of the clientAliases of a service.
                           However a task can't resolve the discovery names. If you want to connect
                           to a service, refer to the ServiceConnectConfiguration of that service for
@@ -1317,7 +1328,6 @@ spec:
                               The configuration for the Amazon EBS volume that Amazon ECS creates and manages
                               on your behalf. These settings are used to create each Amazon EBS volume,
                               with one volume created for each task in the service.
-
 
                               Many of these parameters map 1:1 with the Amazon EBS CreateVolume API request
                               parameters.
@@ -1353,31 +1363,23 @@ spec:
                                           The metadata that you apply to a resource to help you categorize and organize
                                           them. Each tag consists of a key and an optional value. You define them.
 
-
                                           The following basic restrictions apply to tags:
 
-
                                             - Maximum number of tags per resource - 50
-
 
                                             - For each resource, each tag key must be unique, and each tag key can
                                               have only one value.
 
-
                                             - Maximum key length - 128 Unicode characters in UTF-8
 
-
                                             - Maximum value length - 256 Unicode characters in UTF-8
-
 
                                             - If your tagging schema is used across multiple services and resources,
                                               remember that other services may have restrictions on allowed characters.
                                               Generally allowed characters are: letters, numbers, and spaces representable
                                               in UTF-8, and the following characters: + - = . _ : / @.
 
-
                                             - Tag keys and values are case-sensitive.
-
 
                                             - Do not use aws:, AWS:, or any upper or lowercase combination of such
                                               as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1430,7 +1432,6 @@ spec:
                   The operating system that your tasks in the service run on. A platform family
                   is specified only for tasks using the Fargate launch type.
 
-
                   All tasks that run as part of this service must use the same platformFamily
                   value as the service (for example, LINUX).
                 type: string
@@ -1469,23 +1470,19 @@ spec:
                           can be set when using the RunTask or CreateCluster APIs or as the default
                           capacity provider strategy for a cluster with the CreateCluster API.
 
-
                           Only capacity providers that are already associated with a cluster and have
                           an ACTIVE or UPDATING status can be used in a capacity provider strategy.
                           The PutClusterCapacityProviders API is used to associate a capacity provider
                           with a cluster.
 
-
                           If specifying a capacity provider that uses an Auto Scaling group, the capacity
                           provider must already be created. New Auto Scaling group capacity providers
                           can be created with the CreateCapacityProvider API operation.
-
 
                           To use a Fargate capacity provider, specify either the FARGATE or FARGATE_SPOT
                           capacity providers. The Fargate capacity providers are available to all accounts
                           and only need to be associated with a cluster to be used in a capacity provider
                           strategy.
-
 
                           A capacity provider strategy may contain a maximum of 6 capacity providers.
                         properties:
@@ -1518,15 +1515,12 @@ spec:
                         description: |-
                           The load balancer configuration to use with a service or task set.
 
-
                           When you add, update, or remove a load balancer configuration, Amazon ECS
                           starts a new deployment with the updated Elastic Load Balancing configuration.
                           This causes tasks to register to and deregister from load balancers.
 
-
                           We recommend that you verify this on a test environment before you update
                           the Elastic Load Balancing configuration.
-
 
                           A service-linked role is required for services that use multiple target groups.
                           For more information, see Using service-linked roles (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html)
@@ -1539,8 +1533,36 @@ spec:
                             type: integer
                           loadBalancerName:
                             type: string
+                          loadBalancerRef:
+                            description: Reference field for LoadBalancerName
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
                           targetGroupARN:
                             type: string
+                          targetGroupRef:
+                            description: Reference field for TargetGroupARN
+                            properties:
+                              from:
+                                description: |-
+                                  AWSResourceReference provides all the values necessary to reference another
+                                  k8s resource for finding the identifier(Id/ARN/Name)
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
                         type: object
                       type: array
                     networkConfiguration:
@@ -1553,9 +1575,51 @@ spec:
                           properties:
                             assignPublicIP:
                               type: string
+                            securityGroupRefs:
+                              description: Reference field for SecurityGroups
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
                             securityGroups:
                               items:
                                 type: string
+                              type: array
+                            subnetRefs:
+                              description: Reference field for Subnets
+                              items:
+                                description: "AWSResourceReferenceWrapper provides
+                                  a wrapper around *AWSResourceReference\ntype to
+                                  provide more user friendly syntax for references
+                                  using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                                  \ name: my-api"
+                                properties:
+                                  from:
+                                    description: |-
+                                      AWSResourceReference provides all the values necessary to reference another
+                                      k8s resource for finding the identifier(Id/ARN/Name)
+                                    properties:
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    type: object
+                                type: object
                               type: array
                             subnets:
                               items:
@@ -1590,10 +1654,8 @@ spec:
                         description: |-
                           The details for the service registry.
 
-
                           Each service may be associated with one service registry. Multiple service
                           registries for each service are not supported.
-
 
                           When you add, update, or remove the service registries configuration, Amazon
                           ECS starts a new deployment. New tasks are registered and deregistered to
@@ -1626,31 +1688,23 @@ spec:
                           The metadata that you apply to a resource to help you categorize and organize
                           them. Each tag consists of a key and an optional value. You define them.
 
-
                           The following basic restrictions apply to tags:
 
-
                             - Maximum number of tags per resource - 50
-
 
                             - For each resource, each tag key must be unique, and each tag key can
                               have only one value.
 
-
                             - Maximum key length - 128 Unicode characters in UTF-8
 
-
                             - Maximum value length - 256 Unicode characters in UTF-8
-
 
                             - If your tagging schema is used across multiple services and resources,
                               remember that other services may have restrictions on allowed characters.
                               Generally allowed characters are: letters, numbers, and spaces representable
                               in UTF-8, and the following characters: + - = . _ : / @.
 
-
                             - Tag keys and values are case-sensitive.
-
 
                             - Do not use aws:, AWS:, or any upper or lowercase combination of such
                               as a prefix for either keys or values as it is reserved for Amazon Web

--- a/helm/crds/ecs.services.k8s.aws_taskdefinitions.yaml
+++ b/helm/crds/ecs.services.k8s.aws_taskdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: taskdefinitions.ecs.services.k8s.aws
 spec:
   group: ecs.services.k8s.aws
@@ -56,7 +56,6 @@ spec:
             description: |-
               TaskDefinitionSpec defines the desired state of TaskDefinition.
 
-
               The details of a task definition which describes the container and volume
               definitions of an Amazon Elastic Container Service task. You can specify
               which Docker images to use, the required resources, and other configurations
@@ -90,7 +89,6 @@ spec:
                           can contain multiple dependencies. When a dependency is defined for container
                           startup, for container shutdown it is reversed.
 
-
                           Your Amazon ECS container instances require at least version 1.26.0 of the
                           container agent to use container dependencies. However, we recommend using
                           the latest container agent version. For information about checking your agent
@@ -104,16 +102,12 @@ spec:
                           AMI (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html)
                           in the Amazon Elastic Container Service Developer Guide.
 
-
                           For tasks that use the Fargate launch type, the task or service requires
                           the following platforms:
 
-
                             - Linux platform version 1.3.0 or later.
 
-
                             - Windows platform version 1.0.0 or later.
-
 
                           For more information about how to create a container dependency, see Container
                           dependency (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_task_definitions.html#example_task_definition-containerdependency)
@@ -166,7 +160,6 @@ spec:
                           variable in VARIABLE=VALUE format. Lines beginning with # are treated as
                           comments and are ignored.
 
-
                           If there are environment variables specified using the environment parameter
                           in a container definition, they take precedence over the variables contained
                           within an environment file. If multiple environment files are specified that
@@ -175,24 +168,17 @@ spec:
                           environment variables (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html)
                           in the Amazon Elastic Container Service Developer Guide.
 
-
                           You must use the following platforms for the Fargate launch type:
-
 
                             - Linux platform version 1.4.0 or later.
 
-
                             - Windows platform version 1.0.0 or later.
-
 
                           Consider the following when using the Fargate launch type:
 
-
                             - The file is handled like a native Docker env-file.
 
-
                             - There is no support for shell escape handling.
-
 
                             - The container entry point interperts the VARIABLE values.
                         properties:
@@ -238,126 +224,96 @@ spec:
                         or from the image's Dockerfile). This configuration maps to the HEALTHCHECK
                         parameter of docker run (https://docs.docker.com/engine/reference/run/).
 
-
                         The Amazon ECS container agent only monitors and reports on the health checks
                         specified in the task definition. Amazon ECS does not monitor Docker health
                         checks that are embedded in a container image and not specified in the container
                         definition. Health check parameters that are specified in a container definition
                         override any Docker health checks that exist in the container image.
 
-
                         You can view the health status of both individual containers and a task with
                         the DescribeTasks API operation or when viewing the task details in the console.
-
 
                         The health check is designed to make sure that your containers survive agent
                         restarts, upgrades, or temporary unavailability.
 
-
                         The following describes the possible healthStatus values for a container:
-
 
                            * HEALTHY-The container health check has passed successfully.
 
-
                            * UNHEALTHY-The container health check has failed.
-
 
                            * UNKNOWN-The container health check is being evaluated, there's no container
                            health check defined, or Amazon ECS doesn't have the health status of
                            the container.
 
-
                         The following describes the possible healthStatus values based on the container
                         health checker status of essential containers in the task with the following
                         priority order (high to low):
 
-
                            * UNHEALTHY-One or more essential containers have failed their health
                            check.
-
 
                            * UNKNOWN-Any essential container running within the task is in an UNKNOWN
                            state and no other essential containers have an UNHEALTHY state.
 
-
                            * HEALTHY-All essential containers within the task have passed their health
                            checks.
 
-
                         Consider the following task health example with 2 containers.
-
 
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, the task health
                            is UNHEALTHY.
 
-
                            * If Container1 is UNHEALTHY and Container2 is HEALTHY, the task health
                            is UNHEALTHY.
-
 
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, the task health
                            is UNKNOWN.
 
-
                            * If Container1 is HEALTHY and Container2 is HEALTHY, the task health
                            is HEALTHY.
 
-
                         Consider the following task health example with 3 containers.
-
 
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, and Container3
                            is UNKNOWN, the task health is UNHEALTHY.
 
-
                            * If Container1 is UNHEALTHY and Container2 is UNKNOWN, and Container3
                            is HEALTHY, the task health is UNHEALTHY.
-
 
                            * If Container1 is UNHEALTHY and Container2 is HEALTHY, and Container3
                            is HEALTHY, the task health is UNHEALTHY.
 
-
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, and Container3 is
                            HEALTHY, the task health is UNKNOWN.
-
 
                            * If Container1 is HEALTHY and Container2 is UNKNOWN, and Container3 is
                            UNKNOWN, the task health is UNKNOWN.
 
-
                            * If Container1 is HEALTHY and Container2 is HEALTHY, and Container3 is
                            HEALTHY, the task health is HEALTHY.
-
 
                         If a task is run manually, and not as part of a service, the task will continue
                         its lifecycle regardless of its health status. For tasks that are part of
                         a service, if the task reports as unhealthy then the task will be stopped
                         and the service scheduler will replace it.
 
-
                         The following are notes about container health check support:
-
 
                            * When the Amazon ECS agent cannot connect to the Amazon ECS service,
                            the service reports the container as UNHEALTHY.
-
 
                            * The health check statuses are the "last heard from" response from the
                            Amazon ECS agent. There are no assumptions made about the status of the
                            container health checks.
 
-
                            * Container health checks require version 1.17.0 or greater of the Amazon
                            ECS container agent. For more information, see Updating the Amazon ECS
                            container agent (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-update.html).
 
-
                            * Container health checks are supported for Fargate tasks if you're using
                            platform version 1.1.0 or greater. For more information, see Fargate platform
                            versions (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html).
-
 
                            * Container health checks aren't supported for tasks that are part of
                            a service that's configured to use a Classic Load Balancer.
@@ -463,7 +419,6 @@ spec:
                         section of the Docker Remote API (https://docs.docker.com/engine/api/v1.35/)
                         and the --log-driver option to docker run (https://docs.docker.com/engine/reference/commandline/run/).
 
-
                         By default, containers use the same logging driver that the Docker daemon
                         uses. However, the container might use a different logging driver than the
                         Docker daemon by specifying a log driver configuration in the container definition.
@@ -471,9 +426,7 @@ spec:
                         see Configure logging drivers (https://docs.docker.com/engine/admin/logging/overview/)
                         in the Docker documentation.
 
-
                         Understand the following when specifying a log configuration for your containers.
-
 
                            * Amazon ECS currently supports a subset of the logging drivers available
                            to the Docker daemon. Additional log drivers may be available in future
@@ -482,10 +435,8 @@ spec:
                            hosted on Amazon EC2 instances, the supported log drivers are awslogs,
                            fluentd, gelf, json-file, journald, logentries,syslog, splunk, and awsfirelens.
 
-
                            * This parameter requires version 1.18 of the Docker Remote API or greater
                            on your container instance.
-
 
                            * For tasks that are hosted on Amazon EC2 instances, the Amazon ECS container
                            agent must register the available logging drivers with the ECS_AVAILABLE_LOGGING_DRIVERS
@@ -493,7 +444,6 @@ spec:
                            these log configuration options. For more information, see Amazon ECS
                            container agent configuration (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)
                            in the Amazon Elastic Container Service Developer Guide.
-
 
                            * For tasks that are on Fargate, because you don't have access to the
                            underlying infrastructure your tasks are hosted on, any additional software
@@ -513,14 +463,11 @@ spec:
                               An object representing the secret to expose to your container. Secrets can
                               be exposed to a container in the following ways:
 
-
                                 - To inject sensitive data into your containers as environment variables,
                                   use the secrets container definition parameter.
 
-
                                 - To reference sensitive information in the log configuration of a container,
                                   use the secretOptions container definition parameter.
-
 
                               For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                               in the Amazon Elastic Container Service Developer Guide.
@@ -560,11 +507,9 @@ spec:
                           to send or receive traffic. Port mappings are specified as part of the container
                           definition.
 
-
                           If you use containers in a task with the awsvpc or host network mode, specify
                           the exposed ports using containerPort. The hostPort can be left blank or
                           it must be the same value as the containerPort.
-
 
                           Most fields of this parameter (containerPort, hostPort, protocol) maps to
                           PortBindings in the Create a container (https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate)
@@ -573,10 +518,8 @@ spec:
                           If the network mode of a task definition is set to host, host ports must
                           either be undefined or match the container port in the port mapping.
 
-
                           You can't expose the same container port for multiple protocols. If you attempt
                           this, an error is returned.
-
 
                           After a task reaches the RUNNING status, manual and automatic host and container
                           port assignments are visible in the networkBindings section of DescribeTasks
@@ -632,14 +575,11 @@ spec:
                           An object representing the secret to expose to your container. Secrets can
                           be exposed to a container in the following ways:
 
-
                             - To inject sensitive data into your containers as environment variables,
                               use the secrets container definition parameter.
 
-
                             - To reference sensitive information in the log configuration of a container,
                               use the secretOptions container definition parameter.
-
 
                           For more information, see Specifying sensitive data (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html)
                           in the Amazon Elastic Container Service Developer Guide.
@@ -666,11 +606,9 @@ spec:
                           For example, you can configure net.ipv4.tcp_keepalive_time setting to maintain
                           longer lived connections.
 
-
                           We don't recommend that you specify network-related systemControls parameters
                           for multiple containers in a single task that also uses either the awsvpc
                           or host network mode. Doing this has the following disadvantages:
-
 
                             - For tasks that use the awsvpc network mode including Fargate, if you
                               set systemControls for any container, it applies to all containers in
@@ -678,26 +616,20 @@ spec:
                               in a single task, the container that's started last determines which systemControls
                               take effect.
 
-
                             - For tasks that use the host network mode, the network namespace systemControls
                               aren't supported.
-
 
                           If you're setting an IPC resource namespace to use for the containers in
                           the task, the following conditions apply to your system controls. For more
                           information, see IPC mode (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_ipcmode).
 
-
                             - For tasks that use the host IPC mode, IPC namespace systemControls aren't
                               supported.
-
 
                             - For tasks that use the task IPC mode, IPC namespace systemControls values
                               apply to all containers within a task.
 
-
                           This parameter is not supported for Windows containers.
-
 
                           This parameter is only supported for tasks that are hosted on Fargate if
                           the tasks are using platform version 1.4.0 or later (Linux). This isn't supported
@@ -714,13 +646,11 @@ spec:
                         description: |-
                           The ulimit settings to pass to the container.
 
-
                           Amazon ECS tasks hosted on Fargate use the default resource limit values
                           set by the operating system with the exception of the nofile resource limit
                           parameter which Fargate overrides. The nofile resource limit sets a restriction
                           on the number of open files that a container can use. The default nofile
                           soft limit is 1024 and the default hard limit is 65535.
-
 
                           You can specify the ulimit settings for a container in a task definition.
                         properties:
@@ -758,48 +688,37 @@ spec:
                   1 vCPU or 1 vcpu) in a task definition. String values are converted to an
                   integer indicating the CPU units when the task definition is registered.
 
-
                   Task-level CPU and memory parameters are ignored for Windows containers.
                   We recommend specifying container-level resources for Windows containers.
-
 
                   If you're using the EC2 launch type, this field is optional. Supported values
                   are between 128 CPU units (0.125 vCPUs) and 10240 CPU units (10 vCPUs). If
                   you do not specify a value, the parameter is ignored.
 
-
                   If you're using the Fargate launch type, this field is required and you must
                   use one of the following values, which determines your range of supported
                   values for the memory parameter:
 
-
                   The CPU units cannot be less than 1 vCPU when you use Windows containers
                   on Fargate.
-
 
                     - 256 (.25 vCPU) - Available memory values: 512 (0.5 GB), 1024 (1 GB),
                       2048 (2 GB)
 
-
                     - 512 (.5 vCPU) - Available memory values: 1024 (1 GB), 2048 (2 GB), 3072
                       (3 GB), 4096 (4 GB)
-
 
                     - 1024 (1 vCPU) - Available memory values: 2048 (2 GB), 3072 (3 GB), 4096
                       (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB)
 
-
                     - 2048 (2 vCPU) - Available memory values: 4096 (4 GB) and 16384 (16 GB)
                       in increments of 1024 (1 GB)
-
 
                     - 4096 (4 vCPU) - Available memory values: 8192 (8 GB) and 30720 (30 GB)
                       in increments of 1024 (1 GB)
 
-
                     - 8192 (8 vCPU) - Available memory values: 16 GB and 60 GB in 4 GB increments
                       This option requires Linux platform 1.4.0 or later.
-
 
                     - 16384 (16vCPU) - Available memory values: 32GB and 120 GB in 8 GB increments
                       This option requires Linux platform 1.4.0 or later.
@@ -812,13 +731,10 @@ spec:
                   Using data volumes in tasks (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html)
                   in the Amazon ECS Developer Guide.
 
-
                   For tasks using the Fargate launch type, the task requires the following
                   platforms:
 
-
                     - Linux platform version 1.4.0 or later.
-
 
                     - Windows platform version 1.0.0 or later.
                 properties:
@@ -871,25 +787,20 @@ spec:
                   information, see IPC settings (https://docs.docker.com/engine/reference/run/#ipc-settings---ipc)
                   in the Docker run reference.
 
-
                   If the host IPC mode is used, be aware that there is a heightened risk of
                   undesired IPC namespace expose. For more information, see Docker security
                   (https://docs.docker.com/engine/security/security/).
-
 
                   If you are setting namespaced kernel parameters using systemControls for
                   the containers in the task, the following will apply to your IPC resource
                   namespace. For more information, see System Controls (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                     - For tasks that use the host IPC mode, IPC namespace related systemControls
                       are not supported.
 
-
                     - For tasks that use the task IPC mode, IPC namespace related systemControls
                       will apply to all containers within a task.
-
 
                   This parameter is not supported for Windows containers or tasks run on Fargate.
                 type: string
@@ -900,46 +811,35 @@ spec:
                   1GB or 1 GB) in a task definition. String values are converted to an integer
                   indicating the MiB when the task definition is registered.
 
-
                   Task-level CPU and memory parameters are ignored for Windows containers.
                   We recommend specifying container-level resources for Windows containers.
 
-
                   If using the EC2 launch type, this field is optional.
-
 
                   If using the Fargate launch type, this field is required and you must use
                   one of the following values. This determines your range of supported values
                   for the cpu parameter.
 
-
                   The CPU units cannot be less than 1 vCPU when you use Windows containers
                   on Fargate.
-
 
                     - 512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available cpu values: 256 (.25
                       vCPU)
 
-
                     - 1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available cpu values:
                       512 (.5 vCPU)
-
 
                     - 2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168
                       (7 GB), 8192 (8 GB) - Available cpu values: 1024 (1 vCPU)
 
-
                     - Between 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB) -
                       Available cpu values: 2048 (2 vCPU)
-
 
                     - Between 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB) -
                       Available cpu values: 4096 (4 vCPU)
 
-
                     - Between 16 GB and 60 GB in 4 GB increments - Available cpu values: 8192
                       (8 vCPU) This option requires Linux platform 1.4.0 or later.
-
 
                     - Between 32GB and 120 GB in 8 GB increments - Available cpu values: 16384
                       (16 vCPU) This option requires Linux platform 1.4.0 or later.
@@ -950,7 +850,6 @@ spec:
                   values are none, bridge, awsvpc, and host. If no network mode is specified,
                   the default is bridge.
 
-
                   For Amazon ECS tasks on Fargate, the awsvpc network mode is required. For
                   Amazon ECS tasks on Amazon EC2 Linux instances, any network mode can be used.
                   For Amazon ECS tasks on Amazon EC2 Windows instances, <default> or awsvpc
@@ -960,16 +859,13 @@ spec:
                   networking performance for containers because they use the EC2 network stack
                   instead of the virtualized network stack provided by the bridge mode.
 
-
                   With the host and awsvpc network modes, exposed container ports are mapped
                   directly to the corresponding host port (for the host network mode) or the
                   attached elastic network interface port (for the awsvpc network mode), so
                   you cannot take advantage of dynamic host port mappings.
 
-
                   When using the host network mode, you should not run containers using the
                   root user (UID 0). It is considered best practice to use a non-root user.
-
 
                   If the network mode is awsvpc, the task is allocated an elastic network interface,
                   and you must specify a NetworkConfiguration value when you create a service
@@ -977,10 +873,8 @@ spec:
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html)
                   in the Amazon Elastic Container Service Developer Guide.
 
-
                   If the network mode is host, you cannot run multiple instantiations of the
                   same task on a single container instance when port mappings are used.
-
 
                   For more information, see Network settings (https://docs.docker.com/engine/reference/run/#network-settings)
                   in the Docker run reference.
@@ -992,27 +886,21 @@ spec:
                   task. For example, monitoring sidecars might need pidMode to access information
                   about other containers running in the same task.
 
-
                   If host is specified, all containers within the tasks that specified the
                   host PID mode on the same container instance share the same process namespace
                   with the host Amazon EC2 instance.
 
-
                   If task is specified, all containers within the specified task share the
                   same process namespace.
-
 
                   If no value is specified, the default is a private namespace for each container.
                   For more information, see PID settings (https://docs.docker.com/engine/reference/run/#pid-settings---pid)
                   in the Docker run reference.
 
-
                   If the host PID mode is used, there's a heightened risk of undesired process
                   namespace exposure. For more information, see Docker security (https://docs.docker.com/engine/security/security/).
 
-
                   This parameter is not supported for Windows containers.
-
 
                   This parameter is only supported for tasks that are hosted on Fargate if
                   the tasks are using platform version 1.4.0 or later (Linux). This isn't supported
@@ -1029,7 +917,6 @@ spec:
                     see Task placement constraints (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html)
                     in the Amazon Elastic Container Service Developer Guide.
 
-
                     Task placement constraints aren't supported for tasks run on Fargate.
                   properties:
                     expression:
@@ -1041,7 +928,6 @@ spec:
               proxyConfiguration:
                 description: |-
                   The configuration details for the App Mesh proxy.
-
 
                   For tasks hosted on Amazon EC2 instances, the container instances require
                   at least version 1.26.0 of the container agent and at least version 1.26.0-1
@@ -1080,7 +966,6 @@ spec:
                   The operating system that your tasks definitions run on. A platform family
                   is specified only for tasks using the Fargate launch type.
 
-
                   When you specify a task definition in a service, this value must match the
                   runtimePlatform value of the service.
                 properties:
@@ -1095,31 +980,23 @@ spec:
                   and organize them. Each tag consists of a key and an optional value. You
                   define both of them.
 
-
                   The following basic restrictions apply to tags:
 
-
                     - Maximum number of tags per resource - 50
-
 
                     - For each resource, each tag key must be unique, and each tag key can
                       have only one value.
 
-
                     - Maximum key length - 128 Unicode characters in UTF-8
 
-
                     - Maximum value length - 256 Unicode characters in UTF-8
-
 
                     - If your tagging schema is used across multiple services and resources,
                       remember that other services may have restrictions on allowed characters.
                       Generally allowed characters are: letters, numbers, and spaces representable
                       in UTF-8, and the following characters: + - = . _ : / @.
 
-
                     - Tag keys and values are case-sensitive.
-
 
                     - Do not use aws:, AWS:, or any upper or lowercase combination of such
                       as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1130,31 +1007,23 @@ spec:
                     The metadata that you apply to a resource to help you categorize and organize
                     them. Each tag consists of a key and an optional value. You define them.
 
-
                     The following basic restrictions apply to tags:
 
-
                       - Maximum number of tags per resource - 50
-
 
                       - For each resource, each tag key must be unique, and each tag key can
                         have only one value.
 
-
                       - Maximum key length - 128 Unicode characters in UTF-8
 
-
                       - Maximum value length - 256 Unicode characters in UTF-8
-
 
                       - If your tagging schema is used across multiple services and resources,
                         remember that other services may have restrictions on allowed characters.
                         Generally allowed characters are: letters, numbers, and spaces representable
                         in UTF-8, and the following characters: + - = . _ : / @.
 
-
                       - Tag keys and values are case-sensitive.
-
 
                       - Do not use aws:, AWS:, or any upper or lowercase combination of such
                         as a prefix for either keys or values as it is reserved for Amazon Web
@@ -1178,7 +1047,7 @@ spec:
               taskRoleRef:
                 description: "AWSResourceReferenceWrapper provides a wrapper around
                   *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\n\tfrom:\n\t
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
                   \ name: my-api"
                 properties:
                   from:
@@ -1263,7 +1132,6 @@ spec:
                         Server (https://docs.aws.amazon.com/fsx/latest/WindowsGuide/what-is.html)
                         file system for task storage.
 
-
                         For more information and the input format, see Amazon FSx for Windows File
                         Server volumes (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/wfsx-volumes.html)
                         in the Amazon Elastic Container Service Developer Guide.
@@ -1273,7 +1141,6 @@ spec:
                             The authorization configuration details for Amazon FSx for Windows File Server
                             file system. See FSxWindowsFileServerVolumeConfiguration (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_FSxWindowsFileServerVolumeConfiguration.html)
                             in the Amazon ECS API Reference.
-
 
                             For more information and the input format, see Amazon FSx for Windows File
                             Server Volumes (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/wfsx-volumes.html)
@@ -1321,7 +1188,6 @@ spec:
                       when it has verified that an "adopted" resource (a resource where the
                       ARN annotation was set by the Kubernetes user on the CR) exists and
                       matches the supplied CR's Spec field values.
-                      TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
                       https://github.com/aws/aws-controllers-k8s/issues/270
                     type: string
                   ownerAccountID:
@@ -1403,7 +1269,6 @@ spec:
                   for tasks hosted on Amazon EC2 instances. For more information, see Attributes
                   (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html#attributes)
                   in the Amazon Elastic Container Service Developer Guide.
-
 
                   This parameter isn't supported for tasks run on Fargate.
                 items:

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws
@@ -78,10 +78,8 @@ spec:
                       automatically converts this to an arbitrary string-string map.
                       https://github.com/kubernetes-sigs/controller-tools/issues/385
 
-
                       Active discussion about inclusion of this field in the spec is happening in this PR:
                       https://github.com/kubernetes-sigs/controller-tools/pull/395
-
 
                       Until this is allowed, or if it never is, we will produce a subset of the object meta
                       that contains only the fields which the user is allowed to modify in the metadata.
@@ -105,12 +103,10 @@ spec:
                           and may be truncated by the length of the suffix required to make the value
                           unique on the server.
 
-
                           If this field is specified and the generated name exists, the server will
                           NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
                           ServerTimeout indicating a unique name could not be found in the time allotted, and the client
                           should retry (optionally after the time indicated in the Retry-After header).
-
 
                           Applied only if Name is not specified.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
@@ -139,7 +135,6 @@ spec:
                           equivalent to the "default" namespace, but "default" is the canonical representation.
                           Not all objects are required to be scoped to a namespace - the value of this field for
                           those objects will be empty.
-
 
                           Must be a DNS_LABEL.
                           Cannot be updated.

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.2
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -55,6 +55,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - secrets
   verbs:
   - get
   - list
@@ -69,57 +70,20 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
+  - ec2.services.k8s.aws
   resources:
-  - secrets
+  - securitygroups
+  - securitygroups/status
+  - subnets
+  - subnets/status
   verbs:
   - get
   - list
-  - patch
-  - watch
 - apiGroups:
   - ecs.services.k8s.aws
   resources:
   - clusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
-  - clusters/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
   - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
-  - services/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ecs.services.k8s.aws
-  resources:
   - taskdefinitions
   verbs:
   - create
@@ -132,21 +96,27 @@ rules:
 - apiGroups:
   - ecs.services.k8s.aws
   resources:
+  - clusters/status
+  - services/status
   - taskdefinitions/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - iam.services.k8s.aws
+  - elbv2.services.k8s.aws
   resources:
-  - roles
+  - loadbalancers
+  - loadbalancers/status
+  - targetgroups
+  - targetgroups/status
   verbs:
   - get
   - list
 - apiGroups:
   - iam.services.k8s.aws
   resources:
+  - roles
   - roles/status
   verbs:
   - get
@@ -155,25 +125,6 @@ rules:
   - services.k8s.aws
   resources:
   - adoptedresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - services.k8s.aws
-  resources:
-  - adoptedresources/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - services.k8s.aws
-  resources:
   - fieldexports
   verbs:
   - create
@@ -186,6 +137,7 @@ rules:
 - apiGroups:
   - services.k8s.aws
   resources:
+  - adoptedresources/status
   - fieldexports/status
   verbs:
   - get

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -152,6 +152,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           capabilities:
             drop:


### PR DESCRIPTION
This patch regenerates the controller to add a few resource references
for elbv2 LoadBalancer and TargetGroups, and ec2 Subnets and
SecurityGroups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
