### PR TITLE
Update to ACK runtime v0.48.0, code-generator v0.48.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-06-02T19:24:22Z"
-  build_hash: abd45b45e7726b7893641afaeae805281358e684
-  go_version: go1.24.2
-  version: v0.47.2
+  build_date: "2025-06-11T17:48:26Z"
+  build_hash: e675923dfc54d8b6e09730098c3e3e1056d3c1e9
+  go_version: go1.24.3
+  version: v0.48.0
 api_directory_checksum: afecae4373644fadaa4422c3a6a73883d2e571fc
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/ecs-controller
-  newTag: 1.0.12
+  newTag: 1.0.13

--- a/config/controller/service.yaml
+++ b/config/controller/service.yaml
@@ -11,4 +11,4 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
-  type: NodePort
+  type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws-controllers-k8s/ec2-controller v1.2.26
 	github.com/aws-controllers-k8s/elbv2-controller v1.0.0
 	github.com/aws-controllers-k8s/iam-controller v1.3.4
-	github.com/aws-controllers-k8s/runtime v0.47.0
+	github.com/aws-controllers-k8s/runtime v0.48.0
 	github.com/aws/aws-sdk-go v1.50.20
 	github.com/aws/aws-sdk-go-v2 v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.53.11
@@ -71,7 +71,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/aws-controllers-k8s/elbv2-controller v1.0.0 h1:PbtYHf/Fmd9AghPV7TynPZ
 github.com/aws-controllers-k8s/elbv2-controller v1.0.0/go.mod h1:yJ7ajoT/UdDddD2lMq3bAjZZqHplqUFwnLDj2VLnLiU=
 github.com/aws-controllers-k8s/iam-controller v1.3.4 h1:C/CgvJQb6I6mtjgV10FtyWq81S6IhNG+dF4+mjxANEY=
 github.com/aws-controllers-k8s/iam-controller v1.3.4/go.mod h1:8S4IXeK3Y9HABtSwy0Y8X/iBmBH1L/ab1D1cZ0YVlg0=
-github.com/aws-controllers-k8s/runtime v0.47.0 h1:pWzMLrwAFrAmMuSukYDLrQp5Yw594w1ke6XWGmI3uyo=
-github.com/aws-controllers-k8s/runtime v0.47.0/go.mod h1:G2UMBKA7qgXG4JV16NTIUp715uqvUEvWaa7TG1I527U=
+github.com/aws-controllers-k8s/runtime v0.48.0 h1:DnbLQ7gbhQfpOTviR+r+svLjvKhRhxRuNEZo6okZYro=
+github.com/aws-controllers-k8s/runtime v0.48.0/go.mod h1:XNEBK9jN8n19dtHrprn+WlBq9wUc0RspuCmeT4nXb0s=
 github.com/aws/aws-sdk-go v1.50.20 h1:xfAnSDVf/azIWTVQXQODp89bubvCS85r70O3nuQ4dnE=
 github.com/aws/aws-sdk-go v1.50.20/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
@@ -177,8 +177,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
 golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: ecs-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic Container Service (ECS)
-version: 1.0.12
-appVersion: 1.0.12
+version: 1.0.13
+appVersion: 1.0.13
 home: https://github.com/aws-controllers-k8s/ecs-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/ecs-controller:1.0.12".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/ecs-controller:1.0.13".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -204,3 +204,6 @@ spec:
 {{- if .Values.deployment.extraVolumes }}
 {{ toYaml .Values.deployment.extraVolumes | indent 8}}
 {{- end }}
+  {{- with .Values.deployment.strategy }}
+  strategy: {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/ecs-controller
-  tag: 1.0.12
+  tag: 1.0.13
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -41,6 +41,9 @@ deployment:
   # To have DNS options set along with hostNetwork, you have to specify DNS policy
   # explicitly to 'ClusterFirstWithHostNet'.
   dnsPolicy: ClusterFirst
+  # Set rollout strategy for deployment.
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  strategy: {}
   extraVolumes: []
   extraVolumeMounts: []
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
ACK code-generator v0.48.0 [release notes](https://github.com/aws-controllers-k8s/code-generator/releases/tag/v0.48.0)
ACK runtime v0.48.0 [release notes](https://github.com/aws-controllers-k8s/runtime/releases/tag/v0.48.0)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
